### PR TITLE
Update to moveit_simple_controller_manager

### DIFF
--- a/ur5_moveit_config/config/controllers.yaml
+++ b/ur5_moveit_config/config/controllers.yaml
@@ -1,8 +1,7 @@
-controller_manager_ns: pr2_controller_manager
 controller_list:
   - name: ""
-    ns: joint_trajectory_action
-    default: true
+    action_ns: joint_trajectory_action
+    type: FollowJointTrajectory
     joints:
       - shoulder_pan_joint
       - shoulder_lift_joint

--- a/ur5_moveit_config/launch/ur5_moveit_controller_manager.launch
+++ b/ur5_moveit_config/launch/ur5_moveit_controller_manager.launch
@@ -1,17 +1,8 @@
 <launch>
   <arg name="moveit_controller_manager"
-       default="pr2_moveit_controller_manager/Pr2MoveItControllerManager"/>
+       default="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
   <param name="moveit_controller_manager"
          value="$(arg moveit_controller_manager)"/>
-
-  <arg name="controller_manager_name"
-       default="pr2_controller_manager" />
-  <param name="controller_manager_name"
-         value="$(arg controller_manager_name)"/>
-
-  <arg name="use_controller_manager" default="false" />
-  <param name="use_controller_manager"
-         value="$(arg use_controller_manager)" />
 
   <rosparam file="$(find ur5_moveit_config)/config/controllers.yaml"/>
 </launch>

--- a/ur5_moveit_config/package.xml
+++ b/ur5_moveit_config/package.xml
@@ -15,7 +15,7 @@
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
 
   <run_depend>moveit_ros_move_group</run_depend>
-  ]
+  <run_depend>moveit_simple_controller_manager</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
   


### PR DESCRIPTION
Update all moveit_config packages to use moveit_simple_controller_manager, rather than the pr2_controller_manager "hack" currently used.

See ros-industrial/industrial_core#3.
