### PR TITLE
Ignoring unknown pkt types, related to #16.

### DIFF
--- a/ur_driver/src/ur_driver/deserialize.py
+++ b/ur_driver/src/ur_driver/deserialize.py
@@ -199,10 +199,11 @@ class RobotState(object):
     __slots__ = ['robot_mode_data', 'joint_data', 'tool_data',
                  'masterboard_data', 'cartesian_info',
                  'kinematics_info', 'configuration_data',
-                 'force_mode_data', 'additional_info']
+                 'force_mode_data', 'additional_info',
+                 'unknown_ptypes']
 
     def __init__(self):
-        pass
+        self.unknown_ptypes = []
 
     @staticmethod
     def unpack(buf):
@@ -242,7 +243,7 @@ class RobotState(object):
             elif ptype == PackageType.ADDITIONAL_INFO:
                 rs.additional_info = AdditionalInfo.unpack(package_buf)
             else:
-                raise Exception("Unknown package type: %i" % ptype)
+                rs.unknown_ptypes.append(ptype)
         return rs
 
 def pstate(o, indent=''):

--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -186,9 +186,10 @@ class UR5Connection(object):
 
         # Report on any unknown packet types that were received
         if len(state.unknown_ptypes) > 0:
+            state.unknown_ptypes.sort()
             s_unknown_ptypes = [str(ptype) for ptype in state.unknown_ptypes]
             rospy.logwarn("Ignoring unknown pkt type(s): %s. "
-                          "Please report." % ",".join(s_unknown_ptypes))
+                          "Please report." % ", ".join(s_unknown_ptypes))
 
     def __run(self):
         while self.__keep_running:

--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -188,8 +188,15 @@ class UR5Connection(object):
         if len(state.unknown_ptypes) > 0:
             state.unknown_ptypes.sort()
             s_unknown_ptypes = [str(ptype) for ptype in state.unknown_ptypes]
-            rospy.logwarn("Ignoring unknown pkt type(s): %s. "
+            self.throttle_warn_unknown(1.0, "Ignoring unknown pkt type(s): %s. "
                           "Please report." % ", ".join(s_unknown_ptypes))
+
+    def throttle_warn_unknown(self, period, msg):
+        self.__dict__.setdefault('_last_hit', 0.0)
+        # this only works for a single caller
+        if (self._last_hit + period) <= rospy.get_time():
+            self._last_hit = rospy.get_time()
+            rospy.logwarn(msg)
 
     def __run(self):
         while self.__keep_running:

--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -184,6 +184,12 @@ class UR5Connection(object):
                 self.__trigger_halted()
                 self.robot_state = self.CONNECTED
 
+        # Report on any unknown packet types that were received
+        if len(state.unknown_ptypes) > 0:
+            s_unknown_ptypes = [str(ptype) for ptype in state.unknown_ptypes]
+            rospy.logwarn("Ignoring unknown pkt type(s): %s. "
+                          "Please report." % ",".join(s_unknown_ptypes))
+
     def __run(self):
         while self.__keep_running:
             r, _, _ = select.select([self.__sock], [], [], self.TIMEOUT)


### PR DESCRIPTION
This lets the driver ignore unknown packet types, instead of bailing out.

Without rate-limiting the current implementation prints a lot of warnings, this might be nice to fix.

This is against `groovy-devel`, if that is a problem I can rebase on `hydro-devel` as well.
