### PR TITLE
Fix issue #29: missing Beautifulsoup Python dependency

### DIFF
--- a/ur_driver/package.xml
+++ b/ur_driver/package.xml
@@ -46,10 +46,12 @@
   <build_depend>control_msgs</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>control_msgs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
   <run_depend>python-beautifulsoup</run_depend>
 
 

--- a/ur_driver/package.xml
+++ b/ur_driver/package.xml
@@ -50,6 +50,7 @@
   <run_depend>control_msgs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>python-beautifulsoup</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
This adds the missing `run_depend` on `python-beautifulsoup` to `package.xml` of `ur_driver`.

Also adds `run_depend` on `trajectory_msgs`, as that was missing as well.

TODO: I'm not sure the `build_depend` tags are supposed to be there. [Python module dependencies](http://docs.ros.org/groovy/api/catkin/html/howto/python_module_dependencies.html) only talks about `run_depend`. 

---

First reviewed pull-request? @sedwards?
