### PR TITLE
Fix issue #38: add missing run_depend on ind_robot_simulator

### DIFF
--- a/ur5_moveit_config/package.xml
+++ b/ur5_moveit_config/package.xml
@@ -16,6 +16,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_simple_controller_manager</run_depend>
+  <run_depend>industrial_robot_simulator</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
   


### PR DESCRIPTION
As per subject.

I'm not sure, but the UR5 MoveIt config package manifest might be missing some other (run|build)_depends as well.
