### PR TITLE
For issue #56: add deprecation warning to deprecated launch files

### DIFF
--- a/ur_bringup/launch/ur10_bringup_joint_limited.launch
+++ b/ur_bringup/launch/ur10_bringup_joint_limited.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur10 launch. Wraps ur10_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+  
+  Usage:
+    ur10_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+  
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" />
+
+  <include file="$(find ur_bringup)/launch/ur10_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+    <arg name="limited"  value="true"/>
+  </include>
+</launch>

--- a/ur_bringup/launch/ur5_bringup_joint_limited.launch
+++ b/ur_bringup/launch/ur5_bringup_joint_limited.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur5 launch. Wraps ur5_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+  
+  Usage:
+    ur5_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+  
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" />
+
+  <include file="$(find ur_bringup)/launch/ur5_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)" />
+    <arg name="limited"  value="true"/>
+  </include>
+</launch>

--- a/ur_bringup/ur10.launch
+++ b/ur_bringup/ur10.launch
@@ -7,7 +7,7 @@
   Usage:
     ur10.launch robot_ip:=<value>
 -->
-<launch>
+<launch deprecated="This file is deprecated, please use the files in the 'launch' subdirectory">
   
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />

--- a/ur_bringup/ur10_joint_limited.launch
+++ b/ur_bringup/ur10_joint_limited.launch
@@ -7,7 +7,7 @@
   Usage:
     ur10.launch robot_ip:=<value>
 -->
-<launch>
+<launch deprecated="This file is deprecated, please use the files in the 'launch' subdirectory">
   
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />

--- a/ur_bringup/ur5.launch
+++ b/ur_bringup/ur5.launch
@@ -7,7 +7,7 @@
   Usage:
     ur5.launch robot_ip:=<value>
 -->
-<launch>
+<launch deprecated="This file is deprecated, please use the files in the 'launch' subdirectory">
   
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />

--- a/ur_bringup/ur5_joint_limited.launch
+++ b/ur_bringup/ur5_joint_limited.launch
@@ -7,7 +7,7 @@
   Usage:
     ur5.launch robot_ip:=<value>
 -->
-<launch>
+<launch deprecated="This file is deprecated, please use the files in the 'launch' subdirectory">
   
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />

--- a/ur_bringup/ur_common.launch
+++ b/ur_bringup/ur_common.launch
@@ -9,7 +9,7 @@
   Usage:
     ur_common.launch robot_ip:=<value>
 -->
-<launch>
+<launch deprecated="This file is deprecated, please use the files in the 'launch' subdirectory">
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />
   


### PR DESCRIPTION
As discussed in #56, this results in a warning message being printed to the console whenever these launch files are used.

I propose to also delete the joint limited launchfiles from the root of the package: I copied them to the `launch` subdirectory where I think they should be (ie: new files, not deprecated and part of the default set of files). I can add a commit removing those in the root if desired.
