### PR TITLE
Issue/effort limits

### DIFF
--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -77,7 +77,7 @@
     <child link = "${prefix}shoulder_link" />
     <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 0.0 1.0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="2.16"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
   
@@ -107,7 +107,7 @@
     <child link = "${prefix}upper_arm_link" />
     <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />    
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="10.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
 
@@ -139,7 +139,7 @@
     <child link = "${prefix}forearm_link" />
     <origin xyz="0.0 ${-elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 
@@ -169,7 +169,7 @@
     <child link = "${prefix}wrist_1_link" />
     <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 
@@ -201,7 +201,7 @@
     <child link = "${prefix}wrist_2_link" />
     <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 0.0 1.0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 
@@ -233,7 +233,7 @@
     <child link = "${prefix}wrist_3_link" />
     <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 

--- a/ur_description/urdf/ur10_joint_limited.urdf.xacro
+++ b/ur_description/urdf/ur10_joint_limited.urdf.xacro
@@ -77,7 +77,7 @@
     <child link = "${prefix}shoulder_link" />
     <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 0.0 1.0" />
-    <limit lower="${-pi}" upper="${pi}" effort="330.0" velocity="2.16"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="2.16"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
   
@@ -107,7 +107,7 @@
     <child link = "${prefix}upper_arm_link" />
     <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />    
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-pi}" upper="${pi}" effort="10.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
 
@@ -139,7 +139,7 @@
     <child link = "${prefix}forearm_link" />
     <origin xyz="0.0 ${-elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 
@@ -169,7 +169,7 @@
     <child link = "${prefix}wrist_1_link" />
     <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-pi}" upper="${pi}" effort="54.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 
@@ -201,7 +201,7 @@
     <child link = "${prefix}wrist_2_link" />
     <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 0.0 1.0" />
-    <limit lower="${-pi}" upper="${pi}" effort="54.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 
@@ -233,7 +233,7 @@
     <child link = "${prefix}wrist_3_link" />
     <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0.0 1.0 0.0" />
-    <limit lower="${-pi}" upper="${pi}" effort="54.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
 

--- a/ur_description/urdf/ur10_joint_limited_robot.urdf
+++ b/ur_description/urdf/ur10_joint_limited_robot.urdf
@@ -57,7 +57,7 @@
     <child link="shoulder_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.128"/>
     <axis xyz="0.0 0.0 1.0"/>
-    <limit effort="330.0" lower="-3.14159265" upper="3.14159265" velocity="2.16"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="2.16"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
   <link name="shoulder_link">
@@ -83,7 +83,7 @@
     <child link="upper_arm_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.1704 0.0"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="10.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
   <link name="upper_arm_link">
@@ -111,7 +111,7 @@
     <child link="forearm_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 -0.12817 0.60186"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="150.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="forearm_link">
@@ -137,7 +137,7 @@
     <child link="wrist_1_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.0 0.56415"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="54.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="wrist_1_link">
@@ -165,7 +165,7 @@
     <child link="wrist_2_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.11279 0.0"/>
     <axis xyz="0.0 0.0 1.0"/>
-    <limit effort="54.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="wrist_2_link">
@@ -193,7 +193,7 @@
     <child link="wrist_3_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.11279"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="54.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="wrist_3_link">

--- a/ur_description/urdf/ur10_robot.urdf
+++ b/ur_description/urdf/ur10_robot.urdf
@@ -57,7 +57,7 @@
     <child link="shoulder_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.128"/>
     <axis xyz="0.0 0.0 1.0"/>
-    <limit effort="330.0" lower="-6.2831853" upper="6.2831853" velocity="2.16"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="2.16"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
   <link name="shoulder_link">
@@ -83,7 +83,7 @@
     <child link="upper_arm_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.1704 0.0"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="10.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="1.2" friction="0.0"/>
   </joint>
   <link name="upper_arm_link">
@@ -111,7 +111,7 @@
     <child link="forearm_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 -0.12817 0.60186"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="150.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="forearm_link">
@@ -137,7 +137,7 @@
     <child link="wrist_1_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.0 0.56415"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="54.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="wrist_1_link">
@@ -165,7 +165,7 @@
     <child link="wrist_2_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.11279 0.0"/>
     <axis xyz="0.0 0.0 1.0"/>
-    <limit effort="54.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="wrist_2_link">
@@ -193,7 +193,7 @@
     <child link="wrist_3_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.11279"/>
     <axis xyz="0.0 1.0 0.0"/>
-    <limit effort="54.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="0.6" friction="0.0"/>
   </joint>
   <link name="wrist_3_link">

--- a/ur_description/urdf/ur5.urdf.xacro
+++ b/ur_description/urdf/ur5.urdf.xacro
@@ -75,7 +75,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}shoulder_link" />
     <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   
@@ -103,7 +103,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}upper_arm_link" />
     <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />    
     <axis xyz="0 1 0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
 
@@ -132,7 +132,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}forearm_link" />
     <origin xyz="0.0 ${-elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
-    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
 
@@ -160,7 +160,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}wrist_1_link" />
     <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
     <axis xyz="0 1 0" />
-    <limit lower="${-1.0 * pi}" upper="${0.25 * pi}" effort="28.0" velocity="${pi}"/>
+    <limit lower="${-1.0 * pi}" upper="${0.25 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
 
@@ -189,7 +189,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}wrist_2_link" />
     <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
-    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
+    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
 
@@ -218,7 +218,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}wrist_3_link" />
     <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
-    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
+    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
 

--- a/ur_description/urdf/ur5_joint_limited.urdf.xacro
+++ b/ur_description/urdf/ur5_joint_limited.urdf.xacro
@@ -75,7 +75,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}shoulder_link" />
     <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
-    <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   
@@ -103,7 +103,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}upper_arm_link" />
     <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />    
     <axis xyz="0 1 0" />
-    <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
 
@@ -132,7 +132,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}forearm_link" />
     <origin xyz="0.0 ${-elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
-    <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="${pi}"/>
+    <limit lower="${-pi}" upper="${pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
 
@@ -160,7 +160,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}wrist_1_link" />
     <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
     <axis xyz="0 1 0" />
-    <limit lower="${-1.0 * pi}" upper="${0.25 * pi}" effort="28.0" velocity="${pi}"/>
+    <limit lower="${-1.0 * pi}" upper="${0.25 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
 
@@ -189,7 +189,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}wrist_2_link" />
     <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
-    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
+    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
 
@@ -218,7 +218,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <child link = "${prefix}wrist_3_link" />
     <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
-    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
+    <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="1000.0" velocity="${pi}"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
 

--- a/ur_description/urdf/ur5_joint_limited_robot.urdf
+++ b/ur_description/urdf/ur5_joint_limited_robot.urdf
@@ -56,7 +56,7 @@
     <child link="shoulder_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.089159"/>
     <axis xyz="0 0 1"/>
-    <limit effort="150.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   <link name="shoulder_link">
@@ -82,7 +82,7 @@
     <child link="upper_arm_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.13585 0.0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="150.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   <link name="upper_arm_link">
@@ -109,7 +109,7 @@
     <child link="forearm_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 -0.1197 0.425"/>
     <axis xyz="0 1 0"/>
-    <limit effort="150.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   <link name="forearm_link">
@@ -135,7 +135,7 @@
     <child link="wrist_1_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.0 0.39225"/>
     <axis xyz="0 1 0"/>
-    <limit effort="28.0" lower="-3.14159265" upper="0.7853981625" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="0.7853981625" velocity="3.14159265"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
   <link name="wrist_1_link">
@@ -162,7 +162,7 @@
     <child link="wrist_2_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.093 0.0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="28.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
   <link name="wrist_2_link">
@@ -189,7 +189,7 @@
     <child link="wrist_3_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.09465"/>
     <axis xyz="0 1 0"/>
-    <limit effort="28.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
   <link name="wrist_3_link">

--- a/ur_description/urdf/ur5_robot.urdf
+++ b/ur_description/urdf/ur5_robot.urdf
@@ -56,7 +56,7 @@
     <child link="shoulder_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.089159"/>
     <axis xyz="0 0 1"/>
-    <limit effort="150.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   <link name="shoulder_link">
@@ -82,7 +82,7 @@
     <child link="upper_arm_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.13585 0.0"/>
     <axis xyz="0 1 0"/>
-    <limit effort="150.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   <link name="upper_arm_link">
@@ -109,7 +109,7 @@
     <child link="forearm_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 -0.1197 0.425"/>
     <axis xyz="0 1 0"/>
-    <limit effort="150.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-6.2831853" upper="6.2831853" velocity="3.14159265"/>
     <dynamics damping="0.4" friction="0.0"/>
   </joint>
   <link name="forearm_link">
@@ -135,7 +135,7 @@
     <child link="wrist_1_link"/>
     <origin rpy="0.0 1.570796325 0.0" xyz="0.0 0.0 0.39225"/>
     <axis xyz="0 1 0"/>
-    <limit effort="28.0" lower="-3.14159265" upper="0.7853981625" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="0.7853981625" velocity="3.14159265"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
   <link name="wrist_1_link">
@@ -162,7 +162,7 @@
     <child link="wrist_2_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.093 0.0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="28.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
   <link name="wrist_2_link">
@@ -189,7 +189,7 @@
     <child link="wrist_3_link"/>
     <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.09465"/>
     <axis xyz="0 1 0"/>
-    <limit effort="28.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
+    <limit effort="1000.0" lower="-3.14159265" upper="3.14159265" velocity="3.14159265"/>
     <dynamics damping="0.3" friction="0.0"/>
   </joint>
   <link name="wrist_3_link">


### PR DESCRIPTION
The effort limits in the URDFs seem to be too small to properly set up controllers in simulation.
Given the large inertias currently used in the URDFs the small effort limits are too small to be able to move the arm and receive a successful result from the follow_joint_trajectory action.
As I don't know the proper inertias, increasing the effort limits was the easiest fix for now.

At least it can be used in simulation with this PR.
We still can lateron adjust inertias, effort limits and other dynamic parameters in a next iteration.
