### PR TITLE
Fixes for the python driver to work wtih new firmware again

### DIFF
--- a/ur_driver/src/ur_driver/deserialize.py
+++ b/ur_driver/src/ur_driver/deserialize.py
@@ -10,6 +10,7 @@ class PackageType(object):
     CONFIGURATION_DATA = 6
     FORCE_MODE_DATA = 7
     ADDITIONAL_INFO = 8
+    CALIBRATION_DATA = 9
 
 class RobotMode(object):
     RUNNING = 0
@@ -260,6 +261,8 @@ class RobotState(object):
                 rs.force_mode_data = ForceModeData.unpack(package_buf)
             elif ptype == PackageType.ADDITIONAL_INFO:
                 rs.additional_info = AdditionalInfo.unpack(package_buf)
+            elif ptype == PackageType.CALIBRATION_DATA:
+                pass # internal data, should be skipped
             else:
                 rs.unknown_ptypes.append(ptype)
         return rs

--- a/ur_driver/src/ur_driver/deserialize.py
+++ b/ur_driver/src/ur_driver/deserialize.py
@@ -187,13 +187,31 @@ class ForceModeData(object):
          fmd.robot_dexterity) = struct.unpack_from("!IBddddddd", buf)
         return fmd
 
-class AdditionalInfo(object):
+class AdditionalInfoOld(object):
     __slots__ = ['ctrl_bits', 'teach_button']
     @staticmethod
     def unpack(buf):
-        ai = AdditionalInfo()
-        (_, _, ai.ctrl_bits, ai.teach_button) = struct.unpack_from("!IBIB", buf)
+        ai = AdditionalInfoOld()
+        (_,_,ai.ctrl_bits, ai.teach_button) = struct.unpack_from("!IBIB", buf)
         return ai
+        
+class AdditionalInfoNew(object):
+    __slots__ = ['teach_button_enabled','teach_button_pressed']
+    @staticmethod
+    def unpack(buf):
+        ai = AdditionalInfoNew()
+        (_,_,ai.teach_button_enabled, ai.teach_button_pressed) = struct.unpack_from("!IBBB", buf)
+        return ai
+        
+class AdditionalInfo(object):
+    @staticmethod
+    def unpack(buf):
+        ai = AdditionalInfo()
+        (plen, ptype) = struct.unpack_from("!IB", buf)
+        if plen == 10:
+            return AdditionalInfoOld.unpack(buf)
+        else:
+            return AdditionalInfoNew.unpack(buf)
 
 class RobotState(object):
     __slots__ = ['robot_mode_data', 'joint_data', 'tool_data',

--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -16,7 +16,7 @@ from sensor_msgs.msg import JointState
 from control_msgs.msg import FollowJointTrajectoryAction
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 
-from deserialize import RobotState, RobotMode
+from ur_driver.deserialize import RobotState, RobotMode
 
 prevent_programming = False
 


### PR DESCRIPTION
- Fix should be backward-compatible, but was not tested on old firmware yet
- Python package name is needed for working with the release version, otherwise  importing deserialize fails
