### PR TITLE
Issue/tcp force

### DIFF
--- a/ur_driver/prog
+++ b/ur_driver/prog
@@ -33,6 +33,7 @@ def driverProg():
       q = get_joint_positions()
       qdot = get_joint_speeds()
       tau = get_joint_torques()
+      tcp_force = get_tcp_force()
       enter_critical
       socket_send_int(MSG_JOINT_STATES)
       socket_send_int(floor(MULT_jointstate * q[0]))
@@ -53,6 +54,12 @@ def driverProg():
       socket_send_int(floor(MULT_jointstate * tau[3]))
       socket_send_int(floor(MULT_jointstate * tau[4]))
       socket_send_int(floor(MULT_jointstate * tau[5]))
+      socket_send_int(floor(MULT_jointstate * tcp_force[0]))
+      socket_send_int(floor(MULT_jointstate * tcp_force[1]))
+      socket_send_int(floor(MULT_jointstate * tcp_force[2]))
+      socket_send_int(floor(MULT_jointstate * tcp_force[3]))
+      socket_send_int(floor(MULT_jointstate * tcp_force[4]))
+      socket_send_int(floor(MULT_jointstate * tcp_force[5]))
       #socket_send_int(7895160)  # Recognizable  ".xxx" or 00787878
       exit_critical
     end

--- a/ur_driver/prog
+++ b/ur_driver/prog
@@ -33,7 +33,7 @@ def driverProg():
       q = get_joint_positions()
       qdot = get_joint_speeds()
       tau = get_joint_torques()
-      tcp_force = get_tcp_force()
+      wrench = get_tcp_force()
       enter_critical
       socket_send_int(MSG_JOINT_STATES)
       socket_send_int(floor(MULT_jointstate * q[0]))
@@ -54,12 +54,12 @@ def driverProg():
       socket_send_int(floor(MULT_jointstate * tau[3]))
       socket_send_int(floor(MULT_jointstate * tau[4]))
       socket_send_int(floor(MULT_jointstate * tau[5]))
-      socket_send_int(floor(MULT_jointstate * tcp_force[0]))
-      socket_send_int(floor(MULT_jointstate * tcp_force[1]))
-      socket_send_int(floor(MULT_jointstate * tcp_force[2]))
-      socket_send_int(floor(MULT_jointstate * tcp_force[3]))
-      socket_send_int(floor(MULT_jointstate * tcp_force[4]))
-      socket_send_int(floor(MULT_jointstate * tcp_force[5]))
+      socket_send_int(floor(MULT_jointstate * wrench[0]))
+      socket_send_int(floor(MULT_jointstate * wrench[1]))
+      socket_send_int(floor(MULT_jointstate * wrench[2]))
+      socket_send_int(floor(MULT_jointstate * wrench[3]))
+      socket_send_int(floor(MULT_jointstate * wrench[4]))
+      socket_send_int(floor(MULT_jointstate * wrench[5]))
       #socket_send_int(7895160)  # Recognizable  ".xxx" or 00787878
       exit_critical
     end

--- a/ur_driver/prog
+++ b/ur_driver/prog
@@ -8,6 +8,8 @@ def driverProg():
   MSG_WAYPOINT_FINISHED = 5
   MSG_STOPJ = 6
   MSG_SERVOJ = 7
+  MSG_WRENCH = 9
+  MULT_wrench = 10000.0
   MULT_jointstate = 10000.0
   MULT_time = 1000000.0
   MULT_blend = 1000.0
@@ -54,12 +56,13 @@ def driverProg():
       socket_send_int(floor(MULT_jointstate * tau[3]))
       socket_send_int(floor(MULT_jointstate * tau[4]))
       socket_send_int(floor(MULT_jointstate * tau[5]))
-      socket_send_int(floor(MULT_jointstate * wrench[0]))
-      socket_send_int(floor(MULT_jointstate * wrench[1]))
-      socket_send_int(floor(MULT_jointstate * wrench[2]))
-      socket_send_int(floor(MULT_jointstate * wrench[3]))
-      socket_send_int(floor(MULT_jointstate * wrench[4]))
-      socket_send_int(floor(MULT_jointstate * wrench[5]))
+      socket_send_int(MSG_WRENCH)
+      socket_send_int(floor(MULT_wrench * wrench[0]))
+      socket_send_int(floor(MULT_wrench * wrench[1]))
+      socket_send_int(floor(MULT_wrench * wrench[2]))
+      socket_send_int(floor(MULT_wrench * wrench[3]))
+      socket_send_int(floor(MULT_wrench * wrench[4]))
+      socket_send_int(floor(MULT_wrench * wrench[5]))
       #socket_send_int(7895160)  # Recognizable  ".xxx" or 00787878
       exit_critical
     end

--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -52,7 +52,7 @@ Q3 = [1.5,-0.2,-1.57,0,0,0]
 connected_robot = None
 connected_robot_lock = threading.Lock()
 connected_robot_cond = threading.Condition(connected_robot_lock)
-pub_joint_states = rospy.Publisher('joint_states', JointState)
+pub_joint_states = rospy.Publisher('/joint_states', JointState)
 #dump_state = open('dump_state', 'wb')
 
 class EOF(Exception): pass
@@ -633,7 +633,7 @@ class URTrajectoryFollower(object):
 #
 # returns: { "joint_name" : joint_offset }
 def load_joint_offsets(joint_names):
-    robot_description = rospy.get_param("robot_description")
+    robot_description = rospy.get_param("/robot_description")
     soup = BeautifulSoup(robot_description)
     
     result = {}

--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -284,7 +284,7 @@ class CommanderTCPHandler(SocketServer.BaseRequestHandler):
                             raise Exception("Probably forgot to terminate a string: %s..." % buf[:150])
                     s, buf = buf[:i], buf[i+1:]
                     log("Out: %s" % s)
-#jHERE
+
                 elif mtype == MSG_JOINT_STATES:
                     while len(buf) < 4*(6*4):
                         buf = buf + self.recv_more()


### PR DESCRIPTION
For some applications it could be useful to have the force or torque impacting on the end effector of the robot arm. I added a publisher with a geometry_msgs/Wrench to the driver. The published force and torque are in the base coordinate system of the robot.

Hint: The computed force is dependant on the mount of the robot. There's a possibility to set the mounted pose during runtime. I'll commit this functionality in a later pull request.
