### PR TITLE
Fixed wobbling of the UR5 (UR10 untouched).

### DIFF
--- a/ur_description/urdf/ur5.urdf.xacro
+++ b/ur_description/urdf/ur5.urdf.xacro
@@ -66,7 +66,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     </collision>
     <inertial>
       <mass value="${base_mass}" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -76,7 +76,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
     <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="${pi}"/>
-    <dynamics damping="0.4" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
   
   <link name="${prefix}shoulder_link">
@@ -93,7 +93,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     </collision>
     <inertial>
       <mass value="${shoulder_mass}" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
       <origin xyz="${shoulder_cog}" rpy="0.0 0.0 0.0" />
     </inertial>
   </link>
@@ -104,7 +104,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />    
     <axis xyz="0 1 0" />
     <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="${pi}"/>
-    <dynamics damping="0.4" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}upper_arm_link">
@@ -122,7 +122,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     </collision>
     <inertial>
       <mass value="${upper_arm_mass}" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
       <origin xyz="${upper_arm_cog}" rpy="0.0 0.0 0.0" />
     </inertial>
   </link>
@@ -133,7 +133,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 ${-elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
     <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="${pi}"/>
-    <dynamics damping="0.4" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}forearm_link">
@@ -151,7 +151,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${forearm_mass}" />
       <origin xyz="${forearm_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -161,7 +161,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
     <axis xyz="0 1 0" />
     <limit lower="${-1.0 * pi}" upper="${0.25 * pi}" effort="28.0" velocity="${pi}"/>
-    <dynamics damping="0.3" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}wrist_1_link">
@@ -180,7 +180,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${wrist_1_mass}" />
       <origin xyz="${wrist_1_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -190,7 +190,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
     <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
-    <dynamics damping="0.3" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}wrist_2_link">
@@ -209,7 +209,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${wrist_2_mass}" />
       <origin xyz="${wrist_2_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -219,7 +219,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
     <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
-    <dynamics damping="0.3" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}wrist_3_link">
@@ -236,7 +236,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${wrist_3_mass}" />
       <origin xyz="${wrist_3_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
   

--- a/ur_description/urdf/ur5_joint_limited.urdf.xacro
+++ b/ur_description/urdf/ur5_joint_limited.urdf.xacro
@@ -66,7 +66,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     </collision>
     <inertial>
       <mass value="${base_mass}" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -76,7 +76,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
     <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="${pi}"/>
-    <dynamics damping="0.4" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
   
   <link name="${prefix}shoulder_link">
@@ -93,7 +93,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     </collision>
     <inertial>
       <mass value="${shoulder_mass}" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
       <origin xyz="${shoulder_cog}" rpy="0.0 0.0 0.0" />
     </inertial>
   </link>
@@ -104,7 +104,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />    
     <axis xyz="0 1 0" />
     <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="${pi}"/>
-    <dynamics damping="0.4" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}upper_arm_link">
@@ -122,7 +122,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     </collision>
     <inertial>
       <mass value="${upper_arm_mass}" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
       <origin xyz="${upper_arm_cog}" rpy="0.0 0.0 0.0" />
     </inertial>
   </link>
@@ -133,7 +133,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 ${-elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
     <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="${pi}"/>
-    <dynamics damping="0.4" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}forearm_link">
@@ -151,7 +151,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${forearm_mass}" />
       <origin xyz="${forearm_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -161,7 +161,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
     <axis xyz="0 1 0" />
     <limit lower="${-1.0 * pi}" upper="${0.25 * pi}" effort="28.0" velocity="${pi}"/>
-    <dynamics damping="0.3" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}wrist_1_link">
@@ -180,7 +180,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${wrist_1_mass}" />
       <origin xyz="${wrist_1_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -190,7 +190,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
     <axis xyz="0 0 1" />
     <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
-    <dynamics damping="0.3" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}wrist_2_link">
@@ -209,7 +209,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${wrist_2_mass}" />
       <origin xyz="${wrist_2_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
 
@@ -219,7 +219,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
     <axis xyz="0 1 0" />
     <limit lower="${-1.0 * pi}" upper="${1.0 * pi}" effort="28.0" velocity="${pi}"/>
-    <dynamics damping="0.3" friction="0.0"/>
+    <dynamics damping="0.5" friction="0.0"/>
   </joint>
 
   <link name="${prefix}wrist_3_link">
@@ -236,7 +236,7 @@ center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 
     <inertial>
       <mass value="${wrist_3_mass}" />
       <origin xyz="${wrist_3_cog}" rpy="0.0 0.0 0.0" />
-      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.02" iyz="0.0" izz="0.002"/>
     </inertial>
   </link>
   

--- a/ur_gazebo/controller/arm_controller_ur5.yaml
+++ b/ur_gazebo/controller/arm_controller_ur5.yaml
@@ -9,12 +9,12 @@ arm_controller:
      - wrist_2_joint
      - wrist_3_joint
   gains:
-    shoulder_pan_joint: {p: 1000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
-    shoulder_lift_joint: {p: 1000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
-    elbow_joint: {p: 1000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
-    wrist_1_joint: {p: 1000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
-    wrist_2_joint: {p: 1000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
-    wrist_3_joint: {p: 1000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
+    shoulder_pan_joint: {p: 10000.0, i: 50.0, d: 500.0, i_clamp: 0.0, i_clamp_min: -100.0, i_clamp_max: 100.0}
+    shoulder_lift_joint: {p: 10000.0, i: 50.0, d: 500.0, i_clamp: 0.0, i_clamp_min: -100.0, i_clamp_max: 100.0}
+    elbow_joint: {p: 10000.0, i: 50.0, d: 50.0, i_clamp: 0.0, i_clamp_min: -100.0, i_clamp_max: 100.0}
+    wrist_1_joint: {p: 10000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
+    wrist_2_joint: {p: 10000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
+    wrist_3_joint: {p: 10000.0, i: 0.0, d: 0.0, i_clamp: 0.0, i_clamp_min: 0.0, i_clamp_max: 0.0}
   constraints:
       goal_time: 0.6
       stopped_velocity_tolerance: 0.5


### PR DESCRIPTION
The default parameters for the UR5 (dynamic params and PID gains) cause the robot to be wobbly, shaky and not very stable. I updated the parameters so the simulation behaves nicely. There is certainly much better to be done (the tracking seems to be laggy), but this is already a much better start. Note that the robot needs to be fixed to the world - which is not the case by default.

The rough updated parameter values were initially provided by jalfonso in http://answers.ros.org/question/157261/manipulator-shakeswobbles/ and refined by me using dynamic reconfigure.

Thanks,

Antoine.
