### PR TITLE
Robot Jerks Upon Interrupt (Fix)

### DIFF
--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -756,7 +756,7 @@ class URTrajectoryFollower(object):
 
             # Inserts the current setpoint at the head of the trajectory
             now = time.time()
-            point0 = sample_traj(self.traj, now)
+            point0 = sample_traj(self.traj, now - self.traj_t0)
             point0.time_from_start = rospy.Duration(0.0)
             goal_handle.get_goal().trajectory.points.insert(0, point0)
             self.traj_t0 = now


### PR DESCRIPTION
Hi. When playing with the test_move.py script included as part of the ur_driver package, a client noticed that running the test_interrupt routine caused a UR10 arm to emergency stop fairly consistently. Running this myself, I noticed that when interrupted with a new trajectory while still executing a previous trajectory, the robot would immediately jump to the first point of the new trajectory.

Closer inspection of the existing code seems to indicate that in the on_goal() function of the trajectory action server in the ur_driver driver.py file, the sample_traj() function was not being called correctly. It used the absolute time (from time.time()) instead of the offset into the previous trajectory which is used in every other call of this particular function.

Making the small change found in my commit seems to fix the "jerking" issue for me.

I should further mention that I did my testing on a UR5 running firmware version 3.0.x and the Hydro-devel branch of universal robot.
