### PR TITLE
[Indigo] Use PositionJointInterface for simulation

### DIFF
--- a/ur_description/urdf/ur10.transmission.xacro
+++ b/ur_description/urdf/ur10.transmission.xacro
@@ -6,7 +6,7 @@
     <transmission name="${prefix}shoulder_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_pan_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_pan_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -16,7 +16,7 @@
     <transmission name="${prefix}shoulder_lift_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_lift_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_lift_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -26,7 +26,7 @@
     <transmission name="${prefix}elbow_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}elbow_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}elbow_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -36,7 +36,7 @@
     <transmission name="${prefix}wrist_1_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_1_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_1_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -46,7 +46,7 @@
     <transmission name="${prefix}wrist_2_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_2_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_2_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -56,7 +56,7 @@
     <transmission name="${prefix}wrist_3_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_3_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_3_motor">
         <mechanicalReduction>1</mechanicalReduction>

--- a/ur_description/urdf/ur10_joint_limited_robot.urdf
+++ b/ur_description/urdf/ur10_joint_limited_robot.urdf
@@ -230,49 +230,55 @@
   </link>
   <transmission name="shoulder_pan_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_pan_joint"/>
+    <joint name="shoulder_pan_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="shoulder_lift_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_lift_joint"/>
+    <joint name="shoulder_lift_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="elbow_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="elbow_joint"/>
+    <joint name="elbow_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_1_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_1_joint"/>
+    <joint name="wrist_1_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_2_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_2_joint"/>
+    <joint name="wrist_2_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_3_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_3_joint"/>
+    <joint name="wrist_3_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_description/urdf/ur10_robot.urdf
+++ b/ur_description/urdf/ur10_robot.urdf
@@ -230,49 +230,55 @@
   </link>
   <transmission name="shoulder_pan_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_pan_joint"/>
+    <joint name="shoulder_pan_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="shoulder_lift_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_lift_joint"/>
+    <joint name="shoulder_lift_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="elbow_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="elbow_joint"/>
+    <joint name="elbow_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_1_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_1_joint"/>
+    <joint name="wrist_1_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_2_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_2_joint"/>
+    <joint name="wrist_2_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_3_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_3_joint"/>
+    <joint name="wrist_3_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_description/urdf/ur5.transmission.xacro
+++ b/ur_description/urdf/ur5.transmission.xacro
@@ -6,7 +6,7 @@
     <transmission name="${prefix}shoulder_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_pan_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_pan_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -16,7 +16,7 @@
     <transmission name="${prefix}shoulder_lift_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_lift_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_lift_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -26,7 +26,7 @@
     <transmission name="${prefix}elbow_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}elbow_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}elbow_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -36,7 +36,7 @@
     <transmission name="${prefix}wrist_1_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_1_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_1_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -46,7 +46,7 @@
     <transmission name="${prefix}wrist_2_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_2_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_2_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -56,7 +56,7 @@
     <transmission name="${prefix}wrist_3_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_3_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_3_motor">
         <mechanicalReduction>1</mechanicalReduction>

--- a/ur_description/urdf/ur5_joint_limited_robot.urdf
+++ b/ur_description/urdf/ur5_joint_limited_robot.urdf
@@ -230,49 +230,55 @@
   </link>
   <transmission name="shoulder_pan_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_pan_joint"/>
+    <joint name="shoulder_pan_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="shoulder_lift_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_lift_joint"/>
+    <joint name="shoulder_lift_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="elbow_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="elbow_joint"/>
+    <joint name="elbow_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_1_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_1_joint"/>
+    <joint name="wrist_1_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_2_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_2_joint"/>
+    <joint name="wrist_2_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_3_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_3_joint"/>
+    <joint name="wrist_3_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_description/urdf/ur5_robot.urdf
+++ b/ur_description/urdf/ur5_robot.urdf
@@ -230,49 +230,55 @@
   </link>
   <transmission name="shoulder_pan_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_pan_joint"/>
+    <joint name="shoulder_pan_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="shoulder_lift_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="shoulder_lift_joint"/>
+    <joint name="shoulder_lift_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="elbow_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="elbow_joint"/>
+    <joint name="elbow_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_1_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_1_joint"/>
+    <joint name="wrist_1_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_2_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_2_joint"/>
+    <joint name="wrist_2_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
   <transmission name="wrist_3_trans">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="wrist_3_joint"/>
+    <joint name="wrist_3_joint">
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
+    </joint>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_gazebo/controller/arm_controller_ur10.yaml
+++ b/ur_gazebo/controller/arm_controller_ur10.yaml
@@ -1,6 +1,5 @@
 arm_controller:
-  type: effort_controllers/JointTrajectoryController
-  topic: "test"
+  type: position_controllers/JointTrajectoryController
   joints:
      - shoulder_pan_joint
      - shoulder_lift_joint
@@ -8,16 +7,9 @@ arm_controller:
      - wrist_1_joint
      - wrist_2_joint
      - wrist_3_joint
-  gains:
-    shoulder_pan_joint: {p: 600.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    shoulder_lift_joint: {p: 1500.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    elbow_joint: {p: 1500.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    wrist_1_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
-    wrist_2_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
-    wrist_3_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   constraints:
       goal_time: 0.6
-      stopped_velocity_tolerance: 0.5
+      stopped_velocity_tolerance: 0.05
       shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
       shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
       elbow_joint: {trajectory: 0.1, goal: 0.1}

--- a/ur_gazebo/controller/arm_controller_ur5.yaml
+++ b/ur_gazebo/controller/arm_controller_ur5.yaml
@@ -1,6 +1,5 @@
 arm_controller:
-  type: effort_controllers/JointTrajectoryController
-  topic: "test"
+  type: position_controllers/JointTrajectoryController
   joints:
      - shoulder_pan_joint
      - shoulder_lift_joint
@@ -8,16 +7,9 @@ arm_controller:
      - wrist_1_joint
      - wrist_2_joint
      - wrist_3_joint
-  gains:
-    shoulder_pan_joint: {p: 10000.0, i: 500.0, d: 200.0, i_clamp: 100.0}
-    shoulder_lift_joint: {p: 10000.0, i: 500.0, d: 200.0, i_clamp: 100.0}
-    elbow_joint: {p: 10000.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    wrist_1_joint: {p: 100.0, i: 0.0, d: 10.0, i_clamp: 0.0}
-    wrist_2_joint: {p: 100.0, i: 0.0, d: 10.0, i_clamp: 0.0}
-    wrist_3_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   constraints:
       goal_time: 0.6
-      stopped_velocity_tolerance: 0.5
+      stopped_velocity_tolerance: 0.05
       shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
       shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
       elbow_joint: {trajectory: 0.1, goal: 0.1}


### PR DESCRIPTION
So far, the gazebo simulation was using the EffortJointInterface within the hardwareInterface tag of the transmission URDFs. (This is probably a copy-and-paste-remnant from PR2-times - as PR2-hardware was effort-controlled). This PullRequest changes the hardwareInterface to a PositionJointInterface to improve and simplify the gazebo simulation. 

There are several reasons that motivate this change.
First of all, the actual universal_robot hardware is **not** effort-controlled but accepts position-setpoints!
So using a PositionJointInterface for simulation as well seems reasonable.
The main advantage of using the PositionJointInterface over a EffortJointInterface is the following:
With the PositionJointInterface the JointTrajectoryController actually becomes a straight position_controllers/JointTrajectoryController which then actually is no more than a kind of forward command controller throughpassing the position setpoints from the FollowJointTrajectory goal to position setpoints for the simulated joints in Gazebo.
As the mapping is now position - position and no longer position - effort, the internal PID within the FollowJointTrajectory controller is no longer needed and the parameter tuning of the PID gains within the controller configuraiton yaml is obsolete!
As this particular issue has been discussed several times already, I assume getting rid of it to be a good thing! 
This PR is also related to #87 in a way that no PID "guessing" is required anymore.
It's stil not the same behavior as the real hardware uses a different joint trajectory interpolation and also the low-level aspects of the UR controller are not considered yet...

With respect to interfaces this changes nothing within the ROS runtime system
Gazebo will behave as an ideal controller setting the simulated joints to the position setpoints. Thus, there is no "jerky" motion or oscillation anymore!

This PullRequest has absolutely no effects on running it with the real hardware!
