### PR TITLE
dynamic reconfigure server for prevent_programming

### DIFF
--- a/ur_driver/CMakeLists.txt
+++ b/ur_driver/CMakeLists.txt
@@ -4,16 +4,19 @@ project(ur_driver)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED dynamic_reconfigure)
 
 catkin_python_setup()
 
+
+generate_dynamic_reconfigure_options(
+  cfg/URDriver.cfg
+)
 
 ###################################
 ## catkin specific configuration ##
 ###################################
 catkin_package()
-
 
 #############
 ## Install ##

--- a/ur_driver/cfg/URDriver.cfg
+++ b/ur_driver/cfg/URDriver.cfg
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+PACKAGE = "ur_driver"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("prevent_programming",   bool_t,   0, "Prevent driver from continuously uploading 'prog'",  False)
+
+exit(gen.generate(PACKAGE, "ur_driver", "URDriver"))

--- a/ur_driver/package.xml
+++ b/ur_driver/package.xml
@@ -15,6 +15,8 @@
   <url type="website">http://ros.org/wiki/ur_driver</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  
   <run_depend>rospy</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>control_msgs</run_depend>
@@ -22,4 +24,5 @@
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>ur_msgs</run_depend>
   <run_depend>python-lxml</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
 </package>


### PR DESCRIPTION
Tested on UR5 v1.8
This works quite nice! Simply check the the parameter in `rqt_reconfigure` before you want to do anything with the robot (teach_mode, other movements from the teach pendant)....after you are done uncheck the parameter again and continue work on ROS side...
