### PR TITLE
driver: Specify explicit queue size when creating publishers.

### DIFF
--- a/ur_driver/src/ur_driver/driver.py
+++ b/ur_driver/src/ur_driver/driver.py
@@ -92,9 +92,9 @@ connected_robot_lock = threading.Lock()
 connected_robot_cond = threading.Condition(connected_robot_lock)
 last_joint_states = None
 last_joint_states_lock = threading.Lock()
-pub_joint_states = rospy.Publisher('joint_states', JointState)
-pub_wrench = rospy.Publisher('wrench', WrenchStamped)
-pub_io_states = rospy.Publisher('io_states', IOStates)
+pub_joint_states = rospy.Publisher('joint_states', JointState, queue_size=10)
+pub_wrench = rospy.Publisher('wrench', WrenchStamped, queue_size=10)
+pub_io_states = rospy.Publisher('io_states', IOStates, queue_size=10)
 #dump_state = open('dump_state', 'wb')
 
 class EOF(Exception): pass


### PR DESCRIPTION
This PR specifies the queue size when creating a publisher to silence warnings from ROS.

`universal_robot/ur_driver/src/ur_driver/driver.py:95: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.`
