### PR TITLE
driver: Fix ParseError in UR script.

### DIFF
--- a/ur_driver/prog
+++ b/ur_driver/prog
@@ -226,4 +226,3 @@ def driverProg():
   
   socket_send_int(MSG_QUIT)
 end
-driverProg()


### PR DESCRIPTION
The last line in the driver UR script causes the robot controller to spit out an error message. Tested with the simulator versions 1.8, 3.0 and 3.1. I'm not sure about older versions, but I know it's not necessary to call your program after sending it. It is executed even if you don't. And apparently it's not just unnecessary but also not possible.

Does anyone know if this was required on older versions of the software? If not this PR fixes the parse errors given by the robot controller.

```
TCPServer: Secondary client connected
NameError: name 'driverProg' is not defined
--------------------------------------
TCPReceiver::parseLine: Parse Error   
driverProg()
--------------------------------------
```
