### PR TITLE
[Hydro] use position hwi

### DIFF
--- a/ur_description/urdf/ur10.transmission.xacro
+++ b/ur_description/urdf/ur10.transmission.xacro
@@ -7,7 +7,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_pan_joint"/>
       <actuator name="${prefix}shoulder_pan_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -16,7 +16,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_lift_joint"/>
       <actuator name="${prefix}shoulder_lift_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -25,7 +25,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}elbow_joint"/>
       <actuator name="${prefix}elbow_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -34,7 +34,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_1_joint"/>
       <actuator name="${prefix}wrist_1_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -43,7 +43,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_2_joint"/>
       <actuator name="${prefix}wrist_2_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -52,7 +52,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_3_joint"/>
       <actuator name="${prefix}wrist_3_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>

--- a/ur_description/urdf/ur10_joint_limited_robot.urdf
+++ b/ur_description/urdf/ur10_joint_limited_robot.urdf
@@ -232,7 +232,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_pan_joint"/>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -240,7 +240,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_lift_joint"/>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -248,7 +248,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="elbow_joint"/>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -256,7 +256,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_1_joint"/>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -264,7 +264,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_2_joint"/>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -272,7 +272,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_3_joint"/>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_description/urdf/ur10_robot.urdf
+++ b/ur_description/urdf/ur10_robot.urdf
@@ -232,7 +232,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_pan_joint"/>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -240,7 +240,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_lift_joint"/>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -248,7 +248,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="elbow_joint"/>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -256,7 +256,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_1_joint"/>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -264,7 +264,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_2_joint"/>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -272,7 +272,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_3_joint"/>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_description/urdf/ur5.transmission.xacro
+++ b/ur_description/urdf/ur5.transmission.xacro
@@ -7,7 +7,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_pan_joint"/>
       <actuator name="${prefix}shoulder_pan_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -16,7 +16,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_lift_joint"/>
       <actuator name="${prefix}shoulder_lift_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -25,7 +25,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}elbow_joint"/>
       <actuator name="${prefix}elbow_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -34,7 +34,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_1_joint"/>
       <actuator name="${prefix}wrist_1_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -43,7 +43,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_2_joint"/>
       <actuator name="${prefix}wrist_2_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>
@@ -52,7 +52,7 @@
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_3_joint"/>
       <actuator name="${prefix}wrist_3_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
     </transmission>

--- a/ur_description/urdf/ur5_joint_limited_robot.urdf
+++ b/ur_description/urdf/ur5_joint_limited_robot.urdf
@@ -232,7 +232,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_pan_joint"/>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -240,7 +240,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_lift_joint"/>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -248,7 +248,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="elbow_joint"/>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -256,7 +256,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_1_joint"/>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -264,7 +264,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_2_joint"/>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -272,7 +272,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_3_joint"/>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_description/urdf/ur5_robot.urdf
+++ b/ur_description/urdf/ur5_robot.urdf
@@ -232,7 +232,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_pan_joint"/>
     <actuator name="shoulder_pan_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -240,7 +240,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="shoulder_lift_joint"/>
     <actuator name="shoulder_lift_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -248,7 +248,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="elbow_joint"/>
     <actuator name="elbow_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -256,7 +256,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_1_joint"/>
     <actuator name="wrist_1_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -264,7 +264,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_2_joint"/>
     <actuator name="wrist_2_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
@@ -272,7 +272,7 @@
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="wrist_3_joint"/>
     <actuator name="wrist_3_motor">
-      <hardwareInterface>EffortJointInterface</hardwareInterface>
+      <hardwareInterface>PositionJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>

--- a/ur_gazebo/controller/arm_controller_ur10.yaml
+++ b/ur_gazebo/controller/arm_controller_ur10.yaml
@@ -1,6 +1,5 @@
 arm_controller:
-  type: effort_controllers/JointTrajectoryController
-  topic: "test"
+  type: position_controllers/JointTrajectoryController
   joints:
      - shoulder_pan_joint
      - shoulder_lift_joint
@@ -8,16 +7,9 @@ arm_controller:
      - wrist_1_joint
      - wrist_2_joint
      - wrist_3_joint
-  gains:
-    shoulder_pan_joint: {p: 600.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    shoulder_lift_joint: {p: 1500.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    elbow_joint: {p: 1500.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    wrist_1_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
-    wrist_2_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
-    wrist_3_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   constraints:
       goal_time: 0.6
-      stopped_velocity_tolerance: 0.5
+      stopped_velocity_tolerance: 0.05
       shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
       shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
       elbow_joint: {trajectory: 0.1, goal: 0.1}

--- a/ur_gazebo/controller/arm_controller_ur5.yaml
+++ b/ur_gazebo/controller/arm_controller_ur5.yaml
@@ -1,6 +1,5 @@
 arm_controller:
-  type: effort_controllers/JointTrajectoryController
-  topic: "test"
+  type: position_controllers/JointTrajectoryController
   joints:
      - shoulder_pan_joint
      - shoulder_lift_joint
@@ -8,16 +7,9 @@ arm_controller:
      - wrist_1_joint
      - wrist_2_joint
      - wrist_3_joint
-  gains:
-    shoulder_pan_joint: {p: 10000.0, i: 500.0, d: 200.0, i_clamp: 100.0}
-    shoulder_lift_joint: {p: 10000.0, i: 500.0, d: 200.0, i_clamp: 100.0}
-    elbow_joint: {p: 10000.0, i: 500.0, d: 100.0, i_clamp: 100.0}
-    wrist_1_joint: {p: 100.0, i: 0.0, d: 10.0, i_clamp: 0.0}
-    wrist_2_joint: {p: 100.0, i: 0.0, d: 10.0, i_clamp: 0.0}
-    wrist_3_joint: {p: 100.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   constraints:
       goal_time: 0.6
-      stopped_velocity_tolerance: 0.5
+      stopped_velocity_tolerance: 0.05
       shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
       shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
       elbow_joint: {trajectory: 0.1, goal: 0.1}


### PR DESCRIPTION
This brings the PositionJointInterface for `hydro-devel` (the respective PR for `indigo-devel` was #161)

Please note:
Due to the fact that there is a [commit](https://github.com/ros-controls/control_toolbox/commit/2fcbf53d22f9b6ea989284ac0a9550e89a3e7542) in the control_toolbox that only made it into `indigo-devel`, you will see the following error message during startup of gazebo

```
[ERROR] [1425406884.020136717, 0.973000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/shoulder_pan_joint
[ERROR] [1425406884.021714216, 0.973000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/shoulder_lift_joint
[ERROR] [1425406884.022994894, 0.973000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/elbow_joint
[ERROR] [1425406884.024173387, 0.973000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/wrist_1_joint
[ERROR] [1425406884.025289588, 0.973000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/wrist_2_joint
[ERROR] [1425406884.026469266, 0.973000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/wrist_3_joint
```

This is **NOT** an error! The JointInterface is correct and joint positions are used to move the joints in gazebo.
If the parameters `/gazebo_ros_control/pid_gains` would be set, the joint_control_method would be `POSITION_PID` again, which means that efforts are generated within the gazebo_ros_control plugin to command the gazebo joints using efforts again....

Have a look at [hydro](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/hydro-devel/gazebo_ros_control/src/default_robot_hw_sim.cpp#L226) and [indigo](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/indigo-devel/gazebo_ros_control/src/default_robot_hw_sim.cpp#L205) for the relevant lines....
