### PR TITLE
[Indigo] crop ik solutions wrt joint_limits

### DIFF
--- a/ur10_moveit_config/config/kinematics.yaml
+++ b/ur10_moveit_config/config/kinematics.yaml
@@ -1,4 +1,3 @@
-## the UR10KinematicsPlugin only works with the unlimited UR10, i.e. limited:=false
 #manipulator:
 #  kinematics_solver: ur_kinematics/UR10KinematicsPlugin
 #  kinematics_solver_search_resolution: 0.005

--- a/ur5_moveit_config/config/kinematics.yaml
+++ b/ur5_moveit_config/config/kinematics.yaml
@@ -1,4 +1,3 @@
-## the UR5KinematicsPlugin only works with the unlimited UR5, i.e. limited:=false
 #manipulator:
 #  kinematics_solver: ur_kinematics/UR5KinematicsPlugin
 #  kinematics_solver_search_resolution: 0.005


### PR DESCRIPTION
This PR crops the ik_solutions provided by ur_kinematics wrt the joint_limits used in the `/robot_description`.
Thus, the same plugin now works for the limited version of the UR5/UR10 as well!
