### PR TITLE
[Indigo] enable self collision in gazebo

### DIFF
--- a/ur_description/urdf/ur10.gazebo.xacro
+++ b/ur_description/urdf/ur10.gazebo.xacro
@@ -2,7 +2,29 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="ur10_arm_gazebo" params="prefix">
-    <!-- nothing to do here at the moment -->
+    
+    <gazebo reference="${prefix}shoulder_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}upper_arm_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}forearm_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}wrist_1_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}wrist_3_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}wrist_2_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}ee_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    
   </xacro:macro>
 
 </robot>

--- a/ur_description/urdf/ur5.gazebo.xacro
+++ b/ur_description/urdf/ur5.gazebo.xacro
@@ -2,7 +2,29 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="ur5_arm_gazebo" params="prefix">
-    <!-- nothing to do here at the moment -->
+    
+    <gazebo reference="${prefix}shoulder_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}upper_arm_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}forearm_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}wrist_1_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}wrist_3_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}wrist_2_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    <gazebo reference="${prefix}ee_link">
+      <selfCollide>true</selfCollide>
+    </gazebo>
+    
   </xacro:macro>
 
 </robot>


### PR DESCRIPTION
This enables self collision of the meshes within Gazebo as requested in #168 

Appearantly, this gazebo tag actually works - in contrary to my [comment](https://github.com/ros-industrial/universal_robot/pull/168#issuecomment-75634973).
(Still the URDF-to-SDF conversion has it's problems - but it appearently does not affect this tag)

However, if meshes now do collide in gazebo, the UR arm "almost explodes", i.e. starts to shake heavily!
Thus, I'm not really convinced by this PR myself, but at least this feature is now in a separate PR and can be tested!

**Do not merge until more feedback is given on this new feature by the community!**
