### PR TITLE
Use RRTConnect planning algorithm by default

### DIFF
--- a/ur10_moveit_config/config/ompl_planning.yaml
+++ b/ur10_moveit_config/config/ompl_planning.yaml
@@ -34,7 +34,6 @@ manipulator:
     - TRRTkConfigDefault
     - PRMkConfigDefault
     - PRMstarkConfigDefault
-  projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.05
 endeffector:
   planner_configs:

--- a/ur10_moveit_config/config/ompl_planning.yaml
+++ b/ur10_moveit_config/config/ompl_planning.yaml
@@ -34,6 +34,8 @@ manipulator:
     - TRRTkConfigDefault
     - PRMkConfigDefault
     - PRMstarkConfigDefault
+  ##Note: commenting the following line lets moveit chose RRTConnect as default planner rather than LBKPIECE
+  #projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.05
 endeffector:
   planner_configs:

--- a/ur5_moveit_config/config/ompl_planning.yaml
+++ b/ur5_moveit_config/config/ompl_planning.yaml
@@ -34,7 +34,6 @@ manipulator:
     - TRRTkConfigDefault
     - PRMkConfigDefault
     - PRMstarkConfigDefault
-  projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.05
 endeffector:
   planner_configs:

--- a/ur5_moveit_config/config/ompl_planning.yaml
+++ b/ur5_moveit_config/config/ompl_planning.yaml
@@ -34,6 +34,8 @@ manipulator:
     - TRRTkConfigDefault
     - PRMkConfigDefault
     - PRMstarkConfigDefault
+  ##Note: commenting the following line lets moveit chose RRTConnect as default planner rather than LBKPIECE
+  #projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
   longest_valid_segment_fraction: 0.05
 endeffector:
   planner_configs:


### PR DESCRIPTION
Fixes bug #193 about slow planning on Indigo

LBKPIECE1 (the previous default) looks to be the wrong planning algorithm for the robot
See also: https://groups.google.com/forum/#!topic/moveit-users/M71T-GaUNgg
