### PR TITLE
add missing dependency for moveit_simple_controller_manager

### DIFF
--- a/ur10_moveit_config/package.xml
+++ b/ur10_moveit_config/package.xml
@@ -17,6 +17,7 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>moveit_plugins</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>

--- a/ur3_moveit_config/package.xml
+++ b/ur3_moveit_config/package.xml
@@ -17,6 +17,7 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>moveit_plugins</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>

--- a/ur5_moveit_config/package.xml
+++ b/ur5_moveit_config/package.xml
@@ -17,6 +17,7 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>moveit_plugins</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
`moveit_plugins` brings in the dependency to `moveit_simple_controller_manager` (see [rosdistro](https://github.com/ros/rosdistro/blob/master/indigo/distribution.yaml#L5236-L5246))

fixes #225 
