### PR TITLE
Adding joint limit variables in .xacro.urdf files

### DIFF
--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -63,7 +63,13 @@
   </xacro:macro>
 
 
-  <xacro:macro name="ur10_robot" params="prefix joint_limited">
+  <xacro:macro name="ur10_robot" params="prefix joint_limited
+		 shoulder_pan_lower_limit    shoulder_pan_upper_limit
+		 shoulder_lift_lower_limit    shoulder_lift_upper_limit
+		 elbow_joint_lower_limit    elbow_joint_upper_limit
+		 wrist_1_lower_limit    wrist_1_upper_limit
+		 wrist_2_lower_limit    wrist_2_upper_limit
+		 wrist_3_lower_limit    wrist_3_upper_limit">
 
     <link name="${prefix}base_link" >
       <visual>
@@ -93,7 +99,7 @@
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
       </xacro:unless>
       <xacro:if value="${joint_limited}">
-        <limit lower="${-pi}" upper="${pi}" effort="330.0" velocity="2.16"/>
+        <limit lower="${shoulder_pan_lower_limit}" upper="${shoulder_pan_upper_limit}" effort="330.0" velocity="2.16"/>
       </xacro:if>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
@@ -126,7 +132,7 @@
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
       </xacro:unless>
       <xacro:if value="${joint_limited}">
-        <limit lower="${-pi}" upper="${pi}" effort="330.0" velocity="2.16"/>
+        <limit lower="${shoulder_lift_lower_limit}" upper="${shoulder_lift_upper_limit}" effort="330.0" velocity="2.16"/>
       </xacro:if>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
@@ -159,7 +165,7 @@
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="3.15"/>
       </xacro:unless>
       <xacro:if value="${joint_limited}">
-        <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.15"/>
+        <limit lower="${elbow_joint_lower_limit}" upper="${elbow_joint_upper_limit}" effort="150.0" velocity="3.15"/>
       </xacro:if>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
@@ -192,7 +198,7 @@
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
       </xacro:unless>
       <xacro:if value="${joint_limited}">
-        <limit lower="${-pi}" upper="${pi}" effort="54.0" velocity="3.2"/>
+        <limit lower="${wrist_1_lower_limit}" upper="${wrist_1_upper_limit}" effort="54.0" velocity="3.2"/>
       </xacro:if>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
@@ -225,7 +231,7 @@
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
       </xacro:unless>
       <xacro:if value="${joint_limited}">
-        <limit lower="${-pi}" upper="${pi}" effort="54.0" velocity="3.2"/>
+        <limit lower="${wrist_2_lower_limit}" upper="${wrist_2_upper_limit}" effort="54.0" velocity="3.2"/>
       </xacro:if>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>
@@ -258,7 +264,7 @@
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
       </xacro:unless>
       <xacro:if value="${joint_limited}">
-        <limit lower="${-pi}" upper="${pi}" effort="54.0" velocity="3.2"/>
+        <limit lower="${wrist_3_lower_limit}" upper="${wrist_3_upper_limit}" effort="54.0" velocity="3.2"/>
       </xacro:if>
       <dynamics damping="0.0" friction="0.0"/>
     </joint>

--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -64,12 +64,12 @@
 
 
   <xacro:macro name="ur10_robot" params="prefix joint_limited
-		 shoulder_pan_lower_limit    shoulder_pan_upper_limit
-		 shoulder_lift_lower_limit    shoulder_lift_upper_limit
-		 elbow_joint_lower_limit    elbow_joint_upper_limit
-		 wrist_1_lower_limit    wrist_1_upper_limit
-		 wrist_2_lower_limit    wrist_2_upper_limit
-		 wrist_3_lower_limit    wrist_3_upper_limit">
+		 shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
+		 shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
+		 elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
+		 wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
+		 wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
+		 wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}">
 
     <link name="${prefix}base_link" >
       <visual>

--- a/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
@@ -9,7 +9,14 @@
   <xacro:include filename="$(find ur_description)/urdf/ur10.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:ur10_robot prefix="" joint_limited="true"/>
+  <xacro:ur10_robot prefix="" joint_limited="true"
+		 shoulder_pan_lower_limit="${-pi}" shoulder_pan_upper_limit="${pi}"
+		 shoulder_lift_lower_limit="${-pi}" shoulder_lift_upper_limit="${pi}"
+		 elbow_joint_lower_limit="${-pi}" elbow_joint_upper_limit="${pi}"
+		 wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
+		 wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
+		 wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+/>
 
   <link name="world" />
 


### PR DESCRIPTION
I added joint limit variables in the ur_description/urdf/ur10.urdf.xacro
 file, to be able to change the limits of each joint quickly. 

From README.md:  
"As MoveIt! seems to have difficulties with finding plans for the UR with full joint limits [-2pi, 2pi], there is a joint_limited version using joint limits restricted to [-pi,pi]. In order to use this joint limited version, simply use the launch file arguments 'limited', i.e.: "

One of our robots operates in a restricted workspace between for example, [pi/2, 3*pi/2] for shoulder_pan_limit_joint, so I think its easier and clearer to change in

 ur_description/urdf/ur10_joint_limited_robot.urdf.xacro

This limits are actuated when joint_limited:=true by default -pi,pi
