### PR TITLE
Moveit planning execution launch files now set controller_joint_names parameter

### DIFF
--- a/ur10_moveit_config/config/joint_names_ur10.yaml
+++ b/ur10_moveit_config/config/joint_names_ur10.yaml
@@ -1,0 +1,1 @@
+controller_joint_names: ['shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint']

--- a/ur10_moveit_config/launch/ur10_moveit_planning_execution.launch
+++ b/ur10_moveit_config/launch/ur10_moveit_planning_execution.launch
@@ -2,7 +2,9 @@
   <arg name="sim" default="false" />
   <arg name="limited" default="false"/>
   <arg name="debug" default="false" />
-    
+
+  <rosparam command="load" file="$(find ur10_moveit_config)/config/joint_names_ur10.yaml"/>
+
   <!-- Remap follow_joint_trajectory -->
   <remap if="$(arg sim)" from="/follow_joint_trajectory" to="/arm_controller/follow_joint_trajectory"/>
   

--- a/ur3_moveit_config/config/joint_names_ur3.yaml
+++ b/ur3_moveit_config/config/joint_names_ur3.yaml
@@ -1,0 +1,1 @@
+controller_joint_names: ['shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint']

--- a/ur3_moveit_config/launch/ur3_moveit_planning_execution.launch
+++ b/ur3_moveit_config/launch/ur3_moveit_planning_execution.launch
@@ -2,7 +2,9 @@
   <arg name="sim" default="false" />
   <arg name="limited" default="false"/>
   <arg name="debug" default="false" />
-    
+
+  <rosparam command="load" file="$(find ur3_moveit_config)/config/joint_names_ur3.yaml"/>
+
   <!-- Remap follow_joint_trajectory -->
   <remap if="$(arg sim)" from="/follow_joint_trajectory" to="/arm_controller/follow_joint_trajectory"/>
   

--- a/ur5_moveit_config/config/joint_names_ur5.yaml
+++ b/ur5_moveit_config/config/joint_names_ur5.yaml
@@ -1,0 +1,1 @@
+controller_joint_names: ['shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint']

--- a/ur5_moveit_config/launch/ur5_moveit_planning_execution.launch
+++ b/ur5_moveit_config/launch/ur5_moveit_planning_execution.launch
@@ -2,7 +2,9 @@
   <arg name="sim" default="false" />
   <arg name="limited" default="false"/>
   <arg name="debug" default="false" />
-    
+
+  <rosparam command="load" file="$(find ur5_moveit_config)/config/joint_names_ur5.yaml"/>
+
   <!-- Remap follow_joint_trajectory -->
   <remap if="$(arg sim)" from="/follow_joint_trajectory" to="/arm_controller/follow_joint_trajectory"/>
   


### PR DESCRIPTION
Per the ROS-Industrial suggested standard, the controller_joint_names parameter is now set to the (non-standard) joint names:
shoulder_pan_joint
shoulder_lift_joint
elbow_joint
wrist_1_joint
wrist_2_joint
wrist_3_joint

See Section 2 [here](http://wiki.ros.org/Industrial/Tutorials/Create_a_MoveIt_Pkg_for_an_Industrial_Robot).
