### PR TITLE
Use c++11 for moveit plugin when available

### DIFF
--- a/ur_kinematics/CMakeLists.txt
+++ b/ur_kinematics/CMakeLists.txt
@@ -14,6 +14,18 @@ catkin_package(
   DEPENDS boost
 )
 
+# If the compiler supports C++11, enable the flag for it. This is needed
+# on kinetic and newer because some headers that moveit headers include
+# use C++11 features.
+#
+# If the compiler doesn't support C++11, then we hope that we're on an older
+# rosdistro and we don't need it.
+#
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(COMPILER_SUPPORTS_CXX11)
+    add_compile_options(-std=c++11)
+endif()
 
 ###########
 ## Build ##


### PR DESCRIPTION
This is needed to compile on kinetic. Otherwise you get shared_ptr errors in geometric_shapes headers, which get included by moveit headers. I've only tested this on xenial/kinetic; can someone make sure I haven't broken compile on indigo?
