### PR TITLE
ur_gazebo: remove run_depend on gazebo_ros_pkgs meta pkg

### DIFF
--- a/ur_gazebo/package.xml
+++ b/ur_gazebo/package.xml
@@ -18,7 +18,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>ur_description</run_depend>
-  <run_depend>gazebo_ros_pkgs</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
   <run_depend>ros_controllers</run_depend>

--- a/ur_gazebo/package.xml
+++ b/ur_gazebo/package.xml
@@ -25,6 +25,7 @@
   <run_depend>joint_trajectory_controller</run_depend>
   <run_depend>effort_controllers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>controller_manager</run_depend>
   
 
   <export>


### PR DESCRIPTION
Causing build error:
`Abandoned <<< ur_gazebo                                                            [ Depends on unknown jobs: gazebo_ros_pkgs ]`
