### PR TITLE
Don't depend on moveit_plugins metapackage

### DIFF
--- a/ur10_moveit_config/package.xml
+++ b/ur10_moveit_config/package.xml
@@ -17,7 +17,8 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>moveit_plugins</run_depend>
+  <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>

--- a/ur3_moveit_config/package.xml
+++ b/ur3_moveit_config/package.xml
@@ -17,7 +17,8 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>moveit_plugins</run_depend>
+  <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>

--- a/ur5_moveit_config/package.xml
+++ b/ur5_moveit_config/package.xml
@@ -17,7 +17,8 @@
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>moveit_plugins</run_depend>
+  <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
Instead, depend on the individual plugin packages needed. Regular packages aren't supposed to depend on metapackages. For an explanation of why, see https://github.com/catkin/catkin_tools/issues/370#issuecomment-219157118

I've tested this on kinetic so far (https://github.com/ros-industrial/universal_robot/pull/254 is also needed to run on kinetic). If someone could test this PR on indigo, that would be great.
