### PR TITLE
Add dependency on new moveit_kinematics package

### DIFF
--- a/ur_kinematics/CMakeLists.txt
+++ b/ur_kinematics/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ur_kinematics)
 
 find_package(catkin REQUIRED COMPONENTS roscpp geometry_msgs moveit_core
-  moveit_ros_planning pluginlib tf_conversions)
+  moveit_kinematics moveit_ros_planning pluginlib tf_conversions)
 
 find_package(Boost REQUIRED COMPONENTS system)
 

--- a/ur_kinematics/package.xml
+++ b/ur_kinematics/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>moveit_core</build_depend>
+  <build_depend>moveit_kinematics</build_depend>
   <build_depend>moveit_ros_planning</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -26,6 +27,7 @@
   <build_depend>boost</build_depend>
 
   <run_depend>moveit_core</run_depend>
+  <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>geometry_msgs</run_depend>


### PR DESCRIPTION
Otherwise ur_kinematics won't build against the kinetic-devel branch of the moveit repo. It fails with:

```
universal_robot/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h:97:74: fatal error: moveit/kdl_kinematics_plugin/chainiksolver_pos_nr_jl_mimic.hpp: No such file or directory
```

In order to build on kinetic right now, with moveit kinetic-devel branch, you will also need the fix in https://github.com/ros-industrial/universal_robot/pull/254

Can someone create a `kinetic-devel` branch that we can merge the various kinetic-specific fixes into?

EDIT: Corrected moveit branch name from "master" to "kinetic-devel"
