### PR TITLE
Reduce longest valid segment fraction to accomodate non-limited version of the UR5

### DIFF
--- a/ur10_moveit_config/config/ompl_planning.yaml
+++ b/ur10_moveit_config/config/ompl_planning.yaml
@@ -67,7 +67,7 @@ manipulator:
     - PRMstarkConfigDefault
   ##Note: commenting the following line lets moveit chose RRTConnect as default planner rather than LBKPIECE
   #projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 endeffector:
   planner_configs:
     - SBLkConfigDefault

--- a/ur3_moveit_config/config/ompl_planning.yaml
+++ b/ur3_moveit_config/config/ompl_planning.yaml
@@ -67,7 +67,7 @@ manipulator:
     - PRMstarkConfigDefault
   ##Note: commenting the following line lets moveit chose RRTConnect as default planner rather than LBKPIECE
   #projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 endeffector:
   planner_configs:
     - SBLkConfigDefault

--- a/ur5_moveit_config/config/ompl_planning.yaml
+++ b/ur5_moveit_config/config/ompl_planning.yaml
@@ -67,7 +67,7 @@ manipulator:
     - PRMstarkConfigDefault
   ##Note: commenting the following line lets moveit chose RRTConnect as default planner rather than LBKPIECE
   #projection_evaluator: joints(shoulder_pan_joint,shoulder_lift_joint)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 endeffector:
   planner_configs:
     - SBLkConfigDefault


### PR DESCRIPTION
0.01 is the value suggested by @davetcoleman. It looks like it works well for self-collisions. Some users may need to reduce this value if they have very small or thin obstacles.

@davetcoleman what are your thoughts on this?
