### PR TITLE
New message definition for the ToolData

### DIFF
--- a/ur_msgs/CMakeLists.txt
+++ b/ur_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ add_message_files(
    IOStates.msg
    RobotStateRTMsg.msg
    MasterboardDataMsg.msg
+   ToolDataMsg.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/ur_msgs/msg/ToolDataMsg.msg
+++ b/ur_msgs/msg/ToolDataMsg.msg
@@ -17,4 +17,4 @@ uint8 TOOL_BOOTLOADER_MODE = 249
 uint8 TOOL_RUNNING_MODE = 253
 uint8 TOOL_IDLE_MODE = 255
 
-uint8 tool_mode # one of TOOL_BOOTLOADER_*
+uint8 tool_mode # one of TOOL_*

--- a/ur_msgs/msg/ToolDataMsg.msg
+++ b/ur_msgs/msg/ToolDataMsg.msg
@@ -8,7 +8,7 @@ int8 analog_input_range2 # one of ANALOG_INPUT_RANGE_*
 int8 analog_input_range3 # one of ANALOG_INPUT_RANGE_*
 float64 analog_input2
 float64 analog_input3
-float32 tool_voltage_48V
+float32 tool_voltage_48v
 uint8 tool_output_voltage
 float32 tool_current
 float32 tool_temperature

--- a/ur_msgs/msg/ToolDataMsg.msg
+++ b/ur_msgs/msg/ToolDataMsg.msg
@@ -1,0 +1,20 @@
+# This data structure contains the ToolData structure
+# used by the Universal Robots controller
+
+int8 ANALOG_INPUT_RANGE_CURRENT = 0
+int8 ANALOG_INPUT_RANGE_VOLTAGE = 1
+
+int8 analog_input_range2 # one of ANALOG_INPUT_RANGE_*
+int8 analog_input_range3 # one of ANALOG_INPUT_RANGE_*
+float64 analog_input2
+float64 analog_input3
+float32 tool_voltage_48V
+uint8 tool_output_voltage
+float32 tool_current
+float32 tool_temperature
+
+uint8 TOOL_BOOTLOADER_MODE = 249
+uint8 TOOL_RUNNING_MODE = 253
+uint8 TOOL_IDLE_MODE = 255
+
+uint8 tool_mode # one of TOOL_BOOTLOADER_*


### PR DESCRIPTION
This PR contains a new message definition for the ToolData that contains the analog inputs from the tool which where not available so far. The message contains numerical constants so that the user can understand the flags and modes easier. 