### PR TITLE
Duplicate \base_link to \world functionality

### DIFF
--- a/ur_description/urdf/ur5_robot.urdf.xacro
+++ b/ur_description/urdf/ur5_robot.urdf.xacro
@@ -11,12 +11,4 @@
   <!-- arm -->
   <xacro:ur5_robot prefix="" joint_limited="false"/>
 
-  <link name="world" />
-
-  <joint name="world_joint" type="fixed">
-    <parent link="world" />
-    <child link = "base_link" />
-    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
-  </joint>
-
 </robot>


### PR DESCRIPTION
The transform between base_link and world is currently located in the [URDF](https://github.com/ros-industrial/universal_robot/blob/indigo-devel/ur_description/urdf/ur5_robot.urdf.xacro#L14):

```
  <link name="world" />

  <joint name="world_joint" type="fixed">
    <parent link="world" />
    <child link = "base_link" />
    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
  </joint>
```

as well as a virtual_joint in MoveIt! [here](https://github.com/ros-industrial/universal_robot/blob/indigo-devel/ur5_moveit_config/config/ur5.srdf#L38)

```
    <virtual_joint name="fixed_base" type="fixed" parent_frame="world" child_link="base_link" />
```

Which is bad for MoveIt! and complains:

```
ros.rosconsole_bridge.console_bridge: Skipping virtual joint 'fixed_base' because its child frame 'base_link' does not match the URDF frame 'world'
```

I propose we remove the fixed link to the world in the URDF, because that is a semantic transform that does not actually describe the robot.