### PR TITLE
Rename 'world' frame to 'robot_base' in URDF

### DIFF
--- a/ur5_moveit_config/config/ur5.srdf
+++ b/ur5_moveit_config/config/ur5.srdf
@@ -35,7 +35,7 @@
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="moveit_ee" parent_link="ee_link" group="endeffector" />
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="fixed_base" type="fixed" parent_frame="world" child_link="base_link" />
+    <virtual_joint name="fixed_base" type="fixed" parent_frame="world" child_link="robot_base" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="base_link" link2="shoulder_link" reason="Adjacent" />
     <disable_collisions link1="ee_link" link2="wrist_1_link" reason="Never" />

--- a/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
@@ -18,10 +18,10 @@
 		 wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
 />
 
-  <link name="world" />
+  <link name="robot_base" />
 
-  <joint name="world_joint" type="fixed">
-    <parent link="world" />
+  <joint name="robot_base_joint" type="fixed">
+    <parent link="robot_base" />
     <child link = "base_link" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>

--- a/ur_description/urdf/ur10_robot.urdf.xacro
+++ b/ur_description/urdf/ur10_robot.urdf.xacro
@@ -11,10 +11,10 @@
   <!-- arm -->
   <xacro:ur10_robot prefix="" joint_limited="false"/>
 
-  <link name="world" />
+  <link name="robot_base" />
 
-  <joint name="world_joint" type="fixed">
-    <parent link="world" />
+  <joint name="robot_base_joint" type="fixed">
+    <parent link="robot_base" />
     <child link = "base_link" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>

--- a/ur_description/urdf/ur3_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur3_joint_limited_robot.urdf.xacro
@@ -11,10 +11,10 @@
   <!-- arm -->
   <xacro:ur3_robot prefix="" joint_limited="true"/>
 
-  <link name="world" />
+  <link name="robot_base" />
 
-  <joint name="world_joint" type="fixed">
-    <parent link="world" />
+  <joint name="robot_base_joint" type="fixed">
+    <parent link="robot_base" />
     <child link = "base_link" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>

--- a/ur_description/urdf/ur3_robot.urdf.xacro
+++ b/ur_description/urdf/ur3_robot.urdf.xacro
@@ -11,10 +11,10 @@
   <!-- arm -->
   <xacro:ur3_robot prefix="" joint_limited="false"/>
 
-  <link name="world" />
+  <link name="robot_base" />
 
-  <joint name="world_joint" type="fixed">
-    <parent link="world" />
+  <joint name="robot_base_joint" type="fixed">
+    <parent link="robot_base" />
     <child link = "base_link" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>

--- a/ur_description/urdf/ur5_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur5_joint_limited_robot.urdf.xacro
@@ -11,10 +11,10 @@
   <!-- arm -->
   <xacro:ur5_robot prefix="" joint_limited="true"/>
 
-  <link name="world" />
+  <link name="robot_base" />
 
-  <joint name="world_joint" type="fixed">
-    <parent link="world" />
+  <joint name="robot_base_joint" type="fixed">
+    <parent link="robot_base" />
     <child link = "base_link" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>

--- a/ur_description/urdf/ur5_robot.urdf.xacro
+++ b/ur_description/urdf/ur5_robot.urdf.xacro
@@ -11,10 +11,10 @@
   <!-- arm -->
   <xacro:ur5_robot prefix="" joint_limited="false"/>
 
-  <link name="world" />
+  <link name="robot_base" />
 
-  <joint name="world_joint" type="fixed">
-    <parent link="world" />
+  <joint name="robot_base_joint" type="fixed">
+    <parent link="robot_base" />
     <child link = "base_link" />
     <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
   </joint>


### PR DESCRIPTION
The transform between base_link and world is currently located in the [URDF](https://github.com/ros-industrial/universal_robot/blob/indigo-devel/ur_description/urdf/ur5_robot.urdf.xacro#L14):

```
  <link name="world" />

  <joint name="world_joint" type="fixed">
    <parent link="world" />
    <child link = "base_link" />
    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
  </joint>
```

as well as a virtual_joint in MoveIt! [here](https://github.com/ros-industrial/universal_robot/blob/indigo-devel/ur5_moveit_config/config/ur5.srdf#L38)

```
    <virtual_joint name="fixed_base" type="fixed" parent_frame="world" child_link="base_link" />
```

Which is bad for MoveIt! and complains:

```
ros.rosconsole_bridge.console_bridge: Skipping virtual joint 'fixed_base' because its child frame 'base_link' does not match the URDF frame 'world'
```

I propose we rename the fixed link to the world in the URDF so that MoveIt! can still modify the world transform to allow the robot to move. I do *not* think we should remove the fixed link in the URDF because the KDL warns about the base link having inertia.