### PR TITLE
Updated urdf::ModelInterface pointer type for ROS Lunar

### DIFF
--- a/ur_kinematics/src/ur_moveit_plugin.cpp
+++ b/ur_kinematics/src/ur_moveit_plugin.cpp
@@ -176,7 +176,11 @@ bool URKinematicsPlugin::initialize(const std::string &robot_description,
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
   const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
+#if ROS_VERSION_MINIMUM(1, 13, 0) 
+  const std::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
+#else
   const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
+#endif
 
   if (!urdf_model || !srdf)
   {


### PR DESCRIPTION
urdf_model changed the shared pointer type from boost::shared_ptr to std::shared_ptr. 

This change is only applied to versions of ROS newer than Lunar. And it was the only change necessary to compile the whole stack into Lunar.