### PR TITLE
Fix UR5 namespace of params for trajectory_execution

### DIFF
--- a/ur5_moveit_config/launch/trajectory_execution.launch.xml
+++ b/ur5_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,9 +7,9 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="ur5" />


### PR DESCRIPTION
Fix UR5 namespace of params for trajectory_execution. It also refer the issue #307 