### PR TITLE
[ur_moveit_plugin] Use full range in IK if joints support it without solution explosion

### DIFF
--- a/ur_kinematics/src/ur_moveit_plugin.cpp
+++ b/ur_kinematics/src/ur_moveit_plugin.cpp
@@ -657,28 +657,22 @@ bool URKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
       
       for(uint16_t j=0; j<6; j++)
       {
-        if((q_ik_sols[i][j] <= ik_chain_info_.limits[j].max_position) && (q_ik_sols[i][j] >= ik_chain_info_.limits[j].min_position))
-        { 
-          valid_solution[j] = q_ik_sols[i][j];
-          valid = true;
-          continue;
-        }
-        else if ((q_ik_sols[i][j] > ik_chain_info_.limits[j].max_position) && (q_ik_sols[i][j]-2*M_PI > ik_chain_info_.limits[j].min_position))
+        double distance = q_ik_sols[i][j] - ik_seed_state[ur_joint_inds_start_+j];
+        if ((distance > M_PI || (q_ik_sols[i][j] > ik_chain_info_.limits[j].max_position)) && (q_ik_sols[i][j]-2*M_PI > ik_chain_info_.limits[j].min_position))
         {
           valid_solution[j] = q_ik_sols[i][j]-2*M_PI;
-          valid = true;
-          continue;
         }
-        else if ((q_ik_sols[i][j] < ik_chain_info_.limits[j].min_position) && (q_ik_sols[i][j]+2*M_PI < ik_chain_info_.limits[j].max_position))
+        else if ((distance < -M_PI || (q_ik_sols[i][j] < ik_chain_info_.limits[j].min_position)) && (q_ik_sols[i][j]+2*M_PI < ik_chain_info_.limits[j].max_position))
         {
           valid_solution[j] = q_ik_sols[i][j]+2*M_PI;
-          valid = true;
-          continue;
+        }
+        else if((q_ik_sols[i][j] <= ik_chain_info_.limits[j].max_position) && (q_ik_sols[i][j] >= ik_chain_info_.limits[j].min_position))
+        {
+          valid_solution[j] = q_ik_sols[i][j];
         }
         else
         {
           valid = false;
-          break;
         }
       }
       


### PR DESCRIPTION
The solver of ur_kinematics returns solutions in range [0,2PI]. #184 fixed this for the limited version by in effect mapping this to [-PI;PI] range. But this didn't address the issue for the full range version.
#305 fixes this by generatic the extra solutions in the full range but this adds quite a lot of solutions.
This PR extends #184 by checking every joint if it is more than 180° away from the seed. If it is, rotating 360° will be beneficial. If the joint limits allow it, the rotation is applied. This always returns the best solutions in the full range of the joint limits.

This, together with #302 and changing longest_valid_segment_fraction to something lower make ur_kinematics usable with full joint range.