### PR TITLE
Backport #315 to indigo

### DIFF
--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -9,8 +9,6 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.transmission.xacro" />
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
-  <xacro:property name="pi" value="3.14159265" />
-
   <!-- Inertia parameters -->
   <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
   <xacro:property name="shoulder_mass" value="7.778" />

--- a/ur_description/urdf/ur3.urdf.xacro
+++ b/ur_description/urdf/ur3.urdf.xacro
@@ -8,8 +8,6 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.transmission.xacro" />
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
-  <xacro:property name="pi" value="3.14159265" />
-
   <!-- Inertia parameters -->
   <xacro:property name="base_mass" value="2.0" />  <!-- This mass might be incorrect -->
   <xacro:property name="shoulder_mass" value="2.0" />

--- a/ur_description/urdf/ur5.urdf.xacro
+++ b/ur_description/urdf/ur5.urdf.xacro
@@ -4,8 +4,6 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.transmission.xacro" />
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
-  <xacro:property name="pi" value="3.14159265" />
-
   <!-- Inertia parameters -->
   <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
   <xacro:property name="shoulder_mass" value="3.7000" />


### PR DESCRIPTION
As Jade+ xacro is used on Indigo as well, remove `pi`.
