### PR TITLE
ur_moveit_plugin: fix compile error with GCC6

### DIFF
--- a/ur_kinematics/src/ur_moveit_plugin.cpp
+++ b/ur_kinematics/src/ur_moveit_plugin.cpp
@@ -175,12 +175,8 @@ bool URKinematicsPlugin::initialize(const std::string &robot_description,
 
   ros::NodeHandle private_handle("~");
   rdf_loader::RDFLoader rdf_loader(robot_description_);
-  const boost::shared_ptr<srdf::Model> &srdf = rdf_loader.getSRDF();
-#if ROS_VERSION_MINIMUM(1, 13, 0) 
-  const std::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
-#else
-  const boost::shared_ptr<urdf::ModelInterface>& urdf_model = rdf_loader.getURDF();
-#endif
+  const srdf::ModelSharedPtr &srdf = rdf_loader.getSRDF();
+  const urdf::ModelInterfaceSharedPtr &urdf_model = rdf_loader.getURDF();
 
   if (!urdf_model || !srdf)
   {


### PR DESCRIPTION
I encountered compile errors with GCC6 under Debian Stretch. Using the abstracted SharedPtr types fixes the problem.

Alternatively, we could use `auto`.