### PR TITLE
Fix overlapping variable names between robot definition files

### DIFF
--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -10,24 +10,24 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
   <!-- Inertia parameters -->
-  <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
-  <xacro:property name="shoulder_mass" value="7.778" />
-  <xacro:property name="upper_arm_mass" value="12.93" />
-  <xacro:property name="forearm_mass" value="3.87" />
-  <xacro:property name="wrist_1_mass" value="1.96" />
-  <xacro:property name="wrist_2_mass" value="1.96" />
-  <xacro:property name="wrist_3_mass" value="0.202" />
+  <xacro:property name="ur10_base_mass" value="4.0" />  <!-- This mass might be incorrect -->
+  <xacro:property name="ur10_shoulder_mass" value="7.778" />
+  <xacro:property name="ur10_upper_arm_mass" value="12.93" />
+  <xacro:property name="ur10_forearm_mass" value="3.87" />
+  <xacro:property name="ur10_wrist_1_mass" value="1.96" />
+  <xacro:property name="ur10_wrist_2_mass" value="1.96" />
+  <xacro:property name="ur10_wrist_3_mass" value="0.202" />
 
   <!-- These parameters are borrowed from the urcontrol.conf file
        but are not verified for the correct permutation.
        The permutation was guessed by looking at the UR5 parameters.
        Serious use of these parameters needs further inspection. -->
-  <xacro:property name="shoulder_cog" value="0.00008 0.00244 -0.037" />
-  <xacro:property name="upper_arm_cog" value="0.00001 0.15061 0.38757" />
-  <xacro:property name="forearm_cog" value="-0.00012 0.06112 0.1984" />
-  <xacro:property name="wrist_1_cog" value="-0.00021 -0.00112 0.02269" />
-  <xacro:property name="wrist_2_cog" value="-0.00021 0.00112 0.002269" />
-  <xacro:property name="wrist_3_cog" value="0 -0.001156 -0.00149" />
+  <xacro:property name="ur10_shoulder_cog" value="0.00008 0.00244 -0.037" />
+  <xacro:property name="ur10_upper_arm_cog" value="0.00001 0.15061 0.38757" />
+  <xacro:property name="ur10_forearm_cog" value="-0.00012 0.06112 0.1984" />
+  <xacro:property name="ur10_wrist_1_cog" value="-0.00021 -0.00112 0.02269" />
+  <xacro:property name="ur10_wrist_2_cog" value="-0.00021 0.00112 0.002269" />
+  <xacro:property name="ur10_wrist_3_cog" value="0 -0.001156 -0.00149" />
 
   <!-- Kinematic model -->
   <!-- Properties from urcontrol.conf -->
@@ -39,16 +39,16 @@
   <xacro:property name="ur10_d6" value="0.0922" />
 
   <!-- Arbitrary offsets for shoulder/elbow joints -->
-  <xacro:property name="shoulder_offset" value="0.220941" />  <!-- measured from model -->
-  <xacro:property name="elbow_offset" value="-0.1719" /> <!-- measured from model -->
+  <xacro:property name="ur10_shoulder_offset" value="0.220941" />  <!-- measured from model -->
+  <xacro:property name="ur10_elbow_offset" value="-0.1719" /> <!-- measured from model -->
 
   <!-- link lengths used in model -->
-  <xacro:property name="shoulder_height" value="${ur10_d1}" />
-  <xacro:property name="upper_arm_length" value="${-ur10_a2}" />
-  <xacro:property name="forearm_length" value="${-ur10_a3}" />
-  <xacro:property name="wrist_1_length" value="${ur10_d4 - elbow_offset - shoulder_offset}" />
-  <xacro:property name="wrist_2_length" value="${ur10_d5}" />
-  <xacro:property name="wrist_3_length" value="${ur10_d6}" />
+  <xacro:property name="ur10_shoulder_height" value="${ur10_d1}" />
+  <xacro:property name="ur10_upper_arm_length" value="${-ur10_a2}" />
+  <xacro:property name="ur10_forearm_length" value="${-ur10_a3}" />
+  <xacro:property name="ur10_wrist_1_length" value="${ur10_d4 - ur10_elbow_offset - ur10_shoulder_offset}" />
+  <xacro:property name="ur10_wrist_2_length" value="${ur10_d5}" />
+  <xacro:property name="ur10_wrist_3_length" value="${ur10_d6}" />
 
   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
     <inertial>
@@ -83,7 +83,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/base.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${base_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${ur10_base_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -91,7 +91,7 @@
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link" />
       <child link = "${prefix}shoulder_link" />
-      <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${ur10_shoulder_height}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -116,7 +116,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/shoulder.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${shoulder_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${ur10_shoulder_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -124,7 +124,7 @@
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
-      <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 ${ur10_shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -149,7 +149,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/upperarm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur10_a2}" mass="${upper_arm_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="${-ur10_a2}" mass="${ur10_upper_arm_mass}">
         <origin xyz="0.0 0.0 ${-ur10_a2/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -157,7 +157,7 @@
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
-      <origin xyz="0.0 ${elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${ur10_elbow_offset} ${ur10_upper_arm_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.15"/>
@@ -182,7 +182,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/forearm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur10_a3}" mass="${forearm_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="${-ur10_a3}" mass="${ur10_forearm_mass}">
         <origin xyz="0.0 0.0 ${-ur10_a3/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -190,7 +190,7 @@
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
       <child link = "${prefix}wrist_1_link" />
-      <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 0.0 ${ur10_forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -215,7 +215,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/wrist1.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_1_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur10_wrist_1_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -223,7 +223,7 @@
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
-      <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${ur10_wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -248,7 +248,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/wrist2.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_2_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur10_wrist_2_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -256,7 +256,7 @@
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
-      <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${ur10_wrist_2_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -281,7 +281,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/wrist3.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_3_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur10_wrist_3_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -289,7 +289,7 @@
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />
       <child link = "${prefix}ee_link" />
-      <origin xyz="0.0 ${wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
+      <origin xyz="0.0 ${ur10_wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
     </joint>
 
     <link name="${prefix}ee_link">
@@ -319,7 +319,7 @@
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}wrist_3_link-tool0_fixed_joint" type="fixed">
-      <origin xyz="0 ${wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
+      <origin xyz="0 ${ur10_wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
       <parent link="${prefix}wrist_3_link"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -9,47 +9,6 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.transmission.xacro" />
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
-  <!-- Inertia parameters -->
-  <xacro:property name="ur10_base_mass" value="4.0" />  <!-- This mass might be incorrect -->
-  <xacro:property name="ur10_shoulder_mass" value="7.778" />
-  <xacro:property name="ur10_upper_arm_mass" value="12.93" />
-  <xacro:property name="ur10_forearm_mass" value="3.87" />
-  <xacro:property name="ur10_wrist_1_mass" value="1.96" />
-  <xacro:property name="ur10_wrist_2_mass" value="1.96" />
-  <xacro:property name="ur10_wrist_3_mass" value="0.202" />
-
-  <!-- These parameters are borrowed from the urcontrol.conf file
-       but are not verified for the correct permutation.
-       The permutation was guessed by looking at the UR5 parameters.
-       Serious use of these parameters needs further inspection. -->
-  <xacro:property name="ur10_shoulder_cog" value="0.00008 0.00244 -0.037" />
-  <xacro:property name="ur10_upper_arm_cog" value="0.00001 0.15061 0.38757" />
-  <xacro:property name="ur10_forearm_cog" value="-0.00012 0.06112 0.1984" />
-  <xacro:property name="ur10_wrist_1_cog" value="-0.00021 -0.00112 0.02269" />
-  <xacro:property name="ur10_wrist_2_cog" value="-0.00021 0.00112 0.002269" />
-  <xacro:property name="ur10_wrist_3_cog" value="0 -0.001156 -0.00149" />
-
-  <!-- Kinematic model -->
-  <!-- Properties from urcontrol.conf -->
-  <xacro:property name="ur10_d1" value="0.1273" />
-  <xacro:property name="ur10_a2" value="-0.612" />
-  <xacro:property name="ur10_a3" value="-0.5723" />
-  <xacro:property name="ur10_d4" value="0.163941" />
-  <xacro:property name="ur10_d5" value="0.1157" />
-  <xacro:property name="ur10_d6" value="0.0922" />
-
-  <!-- Arbitrary offsets for shoulder/elbow joints -->
-  <xacro:property name="ur10_shoulder_offset" value="0.220941" />  <!-- measured from model -->
-  <xacro:property name="ur10_elbow_offset" value="-0.1719" /> <!-- measured from model -->
-
-  <!-- link lengths used in model -->
-  <xacro:property name="ur10_shoulder_height" value="${ur10_d1}" />
-  <xacro:property name="ur10_upper_arm_length" value="${-ur10_a2}" />
-  <xacro:property name="ur10_forearm_length" value="${-ur10_a3}" />
-  <xacro:property name="ur10_wrist_1_length" value="${ur10_d4 - ur10_elbow_offset - ur10_shoulder_offset}" />
-  <xacro:property name="ur10_wrist_2_length" value="${ur10_d5}" />
-  <xacro:property name="ur10_wrist_3_length" value="${ur10_d6}" />
-
   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
     <inertial>
       <mass value="${mass}" />
@@ -60,7 +19,6 @@
     </inertial>
   </xacro:macro>
 
-
   <xacro:macro name="ur10_robot" params="prefix joint_limited
 		 shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
 		 shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
@@ -68,6 +26,47 @@
 		 wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
 		 wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
 		 wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}">
+
+    <!-- Inertia parameters -->
+    <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
+    <xacro:property name="shoulder_mass" value="7.778" />
+    <xacro:property name="upper_arm_mass" value="12.93" />
+    <xacro:property name="forearm_mass" value="3.87" />
+    <xacro:property name="wrist_1_mass" value="1.96" />
+    <xacro:property name="wrist_2_mass" value="1.96" />
+    <xacro:property name="wrist_3_mass" value="0.202" />
+
+    <!-- These parameters are borrowed from the urcontrol.conf file
+        but are not verified for the correct permutation.
+        The permutation was guessed by looking at the UR5 parameters.
+        Serious use of these parameters needs further inspection. -->
+    <xacro:property name="shoulder_cog" value="0.00008 0.00244 -0.037" />
+    <xacro:property name="upper_arm_cog" value="0.00001 0.15061 0.38757" />
+    <xacro:property name="forearm_cog" value="-0.00012 0.06112 0.1984" />
+    <xacro:property name="wrist_1_cog" value="-0.00021 -0.00112 0.02269" />
+    <xacro:property name="wrist_2_cog" value="-0.00021 0.00112 0.002269" />
+    <xacro:property name="wrist_3_cog" value="0 -0.001156 -0.00149" />
+
+    <!-- Kinematic model -->
+    <!-- Properties from urcontrol.conf -->
+    <xacro:property name="d1" value="0.1273" />
+    <xacro:property name="a2" value="-0.612" />
+    <xacro:property name="a3" value="-0.5723" />
+    <xacro:property name="d4" value="0.163941" />
+    <xacro:property name="d5" value="0.1157" />
+    <xacro:property name="d6" value="0.0922" />
+
+    <!-- Arbitrary offsets for shoulder/elbow joints -->
+    <xacro:property name="shoulder_offset" value="0.220941" />  <!-- measured from model -->
+    <xacro:property name="elbow_offset" value="-0.1719" /> <!-- measured from model -->
+
+    <!-- link lengths used in model -->
+    <xacro:property name="shoulder_height" value="${d1}" />
+    <xacro:property name="upper_arm_length" value="${-a2}" />
+    <xacro:property name="forearm_length" value="${-a3}" />
+    <xacro:property name="wrist_1_length" value="${d4 - elbow_offset - shoulder_offset}" />
+    <xacro:property name="wrist_2_length" value="${d5}" />
+    <xacro:property name="wrist_3_length" value="${d6}" />
 
     <link name="${prefix}base_link" >
       <visual>
@@ -83,7 +82,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/base.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${ur10_base_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${base_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -91,7 +90,7 @@
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link" />
       <child link = "${prefix}shoulder_link" />
-      <origin xyz="0.0 0.0 ${ur10_shoulder_height}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -116,7 +115,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/shoulder.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${ur10_shoulder_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${shoulder_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -124,7 +123,7 @@
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
-      <origin xyz="0.0 ${ur10_shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -149,15 +148,15 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/upperarm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur10_a2}" mass="${ur10_upper_arm_mass}">
-        <origin xyz="0.0 0.0 ${-ur10_a2/2.0}" rpy="0 0 0" />
+      <xacro:cylinder_inertial radius="0.075" length="${-a2}" mass="${upper_arm_mass}">
+        <origin xyz="0.0 0.0 ${-a2/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
 
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
-      <origin xyz="0.0 ${ur10_elbow_offset} ${ur10_upper_arm_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.15"/>
@@ -182,15 +181,15 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/forearm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur10_a3}" mass="${ur10_forearm_mass}">
-        <origin xyz="0.0 0.0 ${-ur10_a3/2.0}" rpy="0 0 0" />
+      <xacro:cylinder_inertial radius="0.075" length="${-a3}" mass="${forearm_mass}">
+        <origin xyz="0.0 0.0 ${-a3/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
 
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
       <child link = "${prefix}wrist_1_link" />
-      <origin xyz="0.0 0.0 ${ur10_forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -215,7 +214,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/wrist1.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur10_wrist_1_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_1_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -223,7 +222,7 @@
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
-      <origin xyz="0.0 ${ur10_wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -248,7 +247,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/wrist2.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur10_wrist_2_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_2_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -256,7 +255,7 @@
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
-      <origin xyz="0.0 0.0 ${ur10_wrist_2_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -281,7 +280,7 @@
           <mesh filename="package://ur_description/meshes/ur10/collision/wrist3.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur10_wrist_3_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_3_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -289,7 +288,7 @@
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />
       <child link = "${prefix}ee_link" />
-      <origin xyz="0.0 ${ur10_wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
+      <origin xyz="0.0 ${wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
     </joint>
 
     <link name="${prefix}ee_link">
@@ -319,7 +318,7 @@
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}wrist_3_link-tool0_fixed_joint" type="fixed">
-      <origin xyz="0 ${ur10_wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
+      <origin xyz="0 ${wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
       <parent link="${prefix}wrist_3_link"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/ur_description/urdf/ur3.urdf.xacro
+++ b/ur_description/urdf/ur3.urdf.xacro
@@ -8,48 +8,7 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.transmission.xacro" />
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
-  <!-- Inertia parameters -->
-  <xacro:property name="ur3_base_mass" value="2.0" />  <!-- This mass might be incorrect -->
-  <xacro:property name="ur3_shoulder_mass" value="2.0" />
-  <xacro:property name="ur3_upper_arm_mass" value="3.42" />
-  <xacro:property name="ur3_forearm_mass" value="1.26" />
-  <xacro:property name="ur3_wrist_1_mass" value="0.8" />
-  <xacro:property name="ur3_wrist_2_mass" value="0.8" />
-  <xacro:property name="ur3_wrist_3_mass" value="0.35" />
-
-  <!-- These parameters are borrowed from the urcontrol.conf file
-       but are not verified for the correct permutation.
-       The permutation was guessed by looking at the UR5 parameters.
-       Serious use of these parameters needs further inspection. -->
-  <xacro:property name="ur3_shoulder_cog" value="0.0 -0.02 0.0" />
-  <xacro:property name="ur3_upper_arm_cog" value="0.13 0.0 0.1157" />
-  <xacro:property name="ur3_forearm_cog" value="0.05 0.0 0.0238" />
-  <xacro:property name="ur3_wrist_1_cog" value="0.0 0.0 0.01" />
-  <xacro:property name="ur3_wrist_2_cog" value="0.0 0.0 0.01" />
-  <xacro:property name="ur3_wrist_3_cog" value="0.0 0.0 -0.02" />
-
-  <!-- Kinematic model -->
-  <!-- Properties from urcontrol.conf -->
-  <xacro:property name="ur3_d1" value="0.1519" />
-  <xacro:property name="ur3_a2" value="-0.24365" />
-  <xacro:property name="ur3_a3" value="-0.21325" />
-  <xacro:property name="ur3_d4" value="0.11235" />
-  <xacro:property name="ur3_d5" value="0.08535" />
-  <xacro:property name="ur3_d6" value="0.0819" />
-
-  <!-- Arbitrary offsets for shoulder/elbow joints -->
-  <xacro:property name="ur3_shoulder_offset" value="0.1198" />  <!-- measured from model -->
-  <xacro:property name="ur3_elbow_offset" value="-0.0925" /> <!-- measured from model -->
-
-  <!-- link lengths used in model -->
-  <xacro:property name="ur3_shoulder_height" value="${ur3_d1}" />
-  <xacro:property name="ur3_upper_arm_length" value="${-ur3_a2}" />
-  <xacro:property name="ur3_forearm_length" value="${-ur3_a3}" />
-  <xacro:property name="ur3_wrist_1_length" value="${ur3_d4 - ur3_elbow_offset - ur3_shoulder_offset}" />
-  <xacro:property name="ur3_wrist_2_length" value="${ur3_d5}" />
-  <xacro:property name="ur3_wrist_3_length" value="${ur3_d6}" />
-
-  <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
+   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
     <inertial>
       <mass value="${mass}" />
       <xacro:insert_block name="origin" />
@@ -59,7 +18,6 @@
     </inertial>
   </xacro:macro>
 
-
   <xacro:macro name="ur3_robot" params="prefix joint_limited
      shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
      shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
@@ -67,6 +25,47 @@
      wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
      wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
      wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}">
+
+    <!-- Inertia parameters -->
+    <xacro:property name="base_mass" value="2.0" />  <!-- This mass might be incorrect -->
+    <xacro:property name="shoulder_mass" value="2.0" />
+    <xacro:property name="upper_arm_mass" value="3.42" />
+    <xacro:property name="forearm_mass" value="1.26" />
+    <xacro:property name="wrist_1_mass" value="0.8" />
+    <xacro:property name="wrist_2_mass" value="0.8" />
+    <xacro:property name="wrist_3_mass" value="0.35" />
+
+    <!-- These parameters are borrowed from the urcontrol.conf file
+        but are not verified for the correct permutation.
+        The permutation was guessed by looking at the UR5 parameters.
+        Serious use of these parameters needs further inspection. -->
+    <xacro:property name="shoulder_cog" value="0.0 -0.02 0.0" />
+    <xacro:property name="upper_arm_cog" value="0.13 0.0 0.1157" />
+    <xacro:property name="forearm_cog" value="0.05 0.0 0.0238" />
+    <xacro:property name="wrist_1_cog" value="0.0 0.0 0.01" />
+    <xacro:property name="wrist_2_cog" value="0.0 0.0 0.01" />
+    <xacro:property name="wrist_3_cog" value="0.0 0.0 -0.02" />
+
+    <!-- Kinematic model -->
+    <!-- Properties from urcontrol.conf -->
+    <xacro:property name="d1" value="0.1519" />
+    <xacro:property name="a2" value="-0.24365" />
+    <xacro:property name="a3" value="-0.21325" />
+    <xacro:property name="d4" value="0.11235" />
+    <xacro:property name="d5" value="0.08535" />
+    <xacro:property name="d6" value="0.0819" />
+
+    <!-- Arbitrary offsets for shoulder/elbow joints -->
+    <xacro:property name="shoulder_offset" value="0.1198" />  <!-- measured from model -->
+    <xacro:property name="elbow_offset" value="-0.0925" /> <!-- measured from model -->
+
+    <!-- link lengths used in model -->
+    <xacro:property name="shoulder_height" value="${d1}" />
+    <xacro:property name="upper_arm_length" value="${-a2}" />
+    <xacro:property name="forearm_length" value="${-a3}" />
+    <xacro:property name="wrist_1_length" value="${d4 - elbow_offset - shoulder_offset}" />
+    <xacro:property name="wrist_2_length" value="${d5}" />
+    <xacro:property name="wrist_3_length" value="${d6}" />
 
     <link name="${prefix}base_link" >
       <visual>
@@ -82,7 +81,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/base.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${ur3_base_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${base_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -90,7 +89,7 @@
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link" />
       <child link = "${prefix}shoulder_link" />
-      <origin xyz="0.0 0.0 ${ur3_shoulder_height}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -115,7 +114,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/shoulder.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${ur3_shoulder_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${shoulder_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -123,7 +122,7 @@
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
-      <origin xyz="0.0 ${ur3_shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -148,15 +147,15 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/upperarm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur3_a2}" mass="${ur3_upper_arm_mass}">
-        <origin xyz="0.0 0.0 ${-ur3_a2/2.0}" rpy="0 0 0" />
+      <xacro:cylinder_inertial radius="0.075" length="${-a2}" mass="${upper_arm_mass}">
+        <origin xyz="0.0 0.0 ${-a2/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
 
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
-      <origin xyz="0.0 ${ur3_elbow_offset} ${ur3_upper_arm_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.15"/>
@@ -181,15 +180,15 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/forearm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur3_a3}" mass="${ur3_forearm_mass}">
-        <origin xyz="0.0 0.0 ${-ur3_a3/2.0}" rpy="0 0 0" />
+      <xacro:cylinder_inertial radius="0.075" length="${-a3}" mass="${forearm_mass}">
+        <origin xyz="0.0 0.0 ${-a3/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
 
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
       <child link = "${prefix}wrist_1_link" />
-      <origin xyz="0.0 0.0 ${ur3_forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -214,7 +213,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/wrist1.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur3_wrist_1_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_1_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -222,7 +221,7 @@
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
-      <origin xyz="0.0 ${ur3_wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -247,7 +246,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/wrist2.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur3_wrist_2_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_2_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -255,7 +254,7 @@
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
-      <origin xyz="0.0 0.0 ${ur3_wrist_2_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -280,7 +279,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/wrist3.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur3_wrist_3_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_3_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -288,7 +287,7 @@
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />
       <child link = "${prefix}ee_link" />
-      <origin xyz="0.0 ${ur3_wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
+      <origin xyz="0.0 ${wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
     </joint>
 
     <link name="${prefix}ee_link">
@@ -318,7 +317,7 @@
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}wrist_3_link-tool0_fixed_joint" type="fixed">
-      <origin xyz="0 ${ur3_wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
+      <origin xyz="0 ${wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
       <parent link="${prefix}wrist_3_link"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/ur_description/urdf/ur3.urdf.xacro
+++ b/ur_description/urdf/ur3.urdf.xacro
@@ -9,24 +9,24 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
   <!-- Inertia parameters -->
-  <xacro:property name="base_mass" value="2.0" />  <!-- This mass might be incorrect -->
-  <xacro:property name="shoulder_mass" value="2.0" />
-  <xacro:property name="upper_arm_mass" value="3.42" />
-  <xacro:property name="forearm_mass" value="1.26" />
-  <xacro:property name="wrist_1_mass" value="0.8" />
-  <xacro:property name="wrist_2_mass" value="0.8" />
-  <xacro:property name="wrist_3_mass" value="0.35" />
+  <xacro:property name="ur3_base_mass" value="2.0" />  <!-- This mass might be incorrect -->
+  <xacro:property name="ur3_shoulder_mass" value="2.0" />
+  <xacro:property name="ur3_upper_arm_mass" value="3.42" />
+  <xacro:property name="ur3_forearm_mass" value="1.26" />
+  <xacro:property name="ur3_wrist_1_mass" value="0.8" />
+  <xacro:property name="ur3_wrist_2_mass" value="0.8" />
+  <xacro:property name="ur3_wrist_3_mass" value="0.35" />
 
   <!-- These parameters are borrowed from the urcontrol.conf file
        but are not verified for the correct permutation.
        The permutation was guessed by looking at the UR5 parameters.
        Serious use of these parameters needs further inspection. -->
-  <xacro:property name="shoulder_cog" value="0.0 -0.02 0.0" />
-  <xacro:property name="upper_arm_cog" value="0.13 0.0 0.1157" />
-  <xacro:property name="forearm_cog" value="0.05 0.0 0.0238" />
-  <xacro:property name="wrist_1_cog" value="0.0 0.0 0.01" />
-  <xacro:property name="wrist_2_cog" value="0.0 0.0 0.01" />
-  <xacro:property name="wrist_3_cog" value="0.0 0.0 -0.02" />
+  <xacro:property name="ur3_shoulder_cog" value="0.0 -0.02 0.0" />
+  <xacro:property name="ur3_upper_arm_cog" value="0.13 0.0 0.1157" />
+  <xacro:property name="ur3_forearm_cog" value="0.05 0.0 0.0238" />
+  <xacro:property name="ur3_wrist_1_cog" value="0.0 0.0 0.01" />
+  <xacro:property name="ur3_wrist_2_cog" value="0.0 0.0 0.01" />
+  <xacro:property name="ur3_wrist_3_cog" value="0.0 0.0 -0.02" />
 
   <!-- Kinematic model -->
   <!-- Properties from urcontrol.conf -->
@@ -38,16 +38,16 @@
   <xacro:property name="ur3_d6" value="0.0819" />
 
   <!-- Arbitrary offsets for shoulder/elbow joints -->
-  <xacro:property name="shoulder_offset" value="0.1198" />  <!-- measured from model -->
-  <xacro:property name="elbow_offset" value="-0.0925" /> <!-- measured from model -->
+  <xacro:property name="ur3_shoulder_offset" value="0.1198" />  <!-- measured from model -->
+  <xacro:property name="ur3_elbow_offset" value="-0.0925" /> <!-- measured from model -->
 
   <!-- link lengths used in model -->
-  <xacro:property name="shoulder_height" value="${ur3_d1}" />
-  <xacro:property name="upper_arm_length" value="${-ur3_a2}" />
-  <xacro:property name="forearm_length" value="${-ur3_a3}" />
-  <xacro:property name="wrist_1_length" value="${ur3_d4 - elbow_offset - shoulder_offset}" />
-  <xacro:property name="wrist_2_length" value="${ur3_d5}" />
-  <xacro:property name="wrist_3_length" value="${ur3_d6}" />
+  <xacro:property name="ur3_shoulder_height" value="${ur3_d1}" />
+  <xacro:property name="ur3_upper_arm_length" value="${-ur3_a2}" />
+  <xacro:property name="ur3_forearm_length" value="${-ur3_a3}" />
+  <xacro:property name="ur3_wrist_1_length" value="${ur3_d4 - ur3_elbow_offset - ur3_shoulder_offset}" />
+  <xacro:property name="ur3_wrist_2_length" value="${ur3_d5}" />
+  <xacro:property name="ur3_wrist_3_length" value="${ur3_d6}" />
 
   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
     <inertial>
@@ -82,7 +82,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/base.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${base_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.038" mass="${ur3_base_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -90,7 +90,7 @@
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link" />
       <child link = "${prefix}shoulder_link" />
-      <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${ur3_shoulder_height}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -115,7 +115,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/shoulder.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${shoulder_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.178" mass="${ur3_shoulder_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -123,7 +123,7 @@
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
-      <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 ${ur3_shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="330.0" velocity="2.16"/>
@@ -148,7 +148,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/upperarm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur3_a2}" mass="${upper_arm_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="${-ur3_a2}" mass="${ur3_upper_arm_mass}">
         <origin xyz="0.0 0.0 ${-ur3_a2/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -156,7 +156,7 @@
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
-      <origin xyz="0.0 ${elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${ur3_elbow_offset} ${ur3_upper_arm_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.15"/>
@@ -181,7 +181,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/forearm.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="${-ur3_a3}" mass="${forearm_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="${-ur3_a3}" mass="${ur3_forearm_mass}">
         <origin xyz="0.0 0.0 ${-ur3_a3/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -189,7 +189,7 @@
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
       <child link = "${prefix}wrist_1_link" />
-      <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 0.0 ${ur3_forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -214,7 +214,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/wrist1.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_1_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur3_wrist_1_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -222,7 +222,7 @@
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
-      <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${ur3_wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -247,7 +247,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/wrist2.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_2_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur3_wrist_2_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -255,7 +255,7 @@
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
-      <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${ur3_wrist_2_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="54.0" velocity="3.2"/>
@@ -280,7 +280,7 @@
           <mesh filename="package://ur_description/meshes/ur3/collision/wrist3.stl"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${wrist_3_mass}">
+      <xacro:cylinder_inertial radius="0.075" length="0.12" mass="${ur3_wrist_3_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -288,7 +288,7 @@
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />
       <child link = "${prefix}ee_link" />
-      <origin xyz="0.0 ${wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
+      <origin xyz="0.0 ${ur3_wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
     </joint>
 
     <link name="${prefix}ee_link">
@@ -318,7 +318,7 @@
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}wrist_3_link-tool0_fixed_joint" type="fixed">
-      <origin xyz="0 ${wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
+      <origin xyz="0 ${ur3_wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
       <parent link="${prefix}wrist_3_link"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/ur_description/urdf/ur5.urdf.xacro
+++ b/ur_description/urdf/ur5.urdf.xacro
@@ -4,67 +4,6 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.transmission.xacro" />
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
-  <!-- Inertia parameters -->
-  <xacro:property name="ur5_base_mass" value="4.0" />  <!-- This mass might be incorrect -->
-  <xacro:property name="ur5_shoulder_mass" value="3.7000" />
-  <xacro:property name="ur5_upper_arm_mass" value="8.3930" />
-  <xacro:property name="ur5_forearm_mass" value="2.2750" />
-  <xacro:property name="ur5_wrist_1_mass" value="1.2190" />
-  <xacro:property name="ur5_wrist_2_mass" value="1.2190" />
-  <xacro:property name="ur5_wrist_3_mass" value="0.1879" />
-
-  <xacro:property name="ur5_shoulder_cog" value="0.0 0.00193 -0.02561" />
-  <xacro:property name="ur5_upper_arm_cog" value="0.0 -0.024201 0.2125" />
-  <xacro:property name="ur5_forearm_cog" value="0.0 0.0265 0.11993" />
-  <xacro:property name="ur5_wrist_1_cog" value="0.0 0.110949 0.01634" />
-  <xacro:property name="ur5_wrist_2_cog" value="0.0 0.0018 0.11099" />
-  <xacro:property name="ur5_wrist_3_cog" value="0.0 0.001159 0.0" />
-
-  <!-- Kinematic model -->
-  <!-- Properties from urcontrol.conf -->
-  <!--
-    DH for UR5:
-    a = [0.00000, -0.42500, -0.39225,  0.00000,  0.00000,  0.0000]
-    d = [0.089159,  0.00000,  0.00000,  0.10915,  0.09465,  0.0823]
-    alpha = [ 1.570796327, 0, 0, 1.570796327, -1.570796327, 0 ]
-    q_home_offset = [0, -1.570796327, 0, -1.570796327, 0, 0]
-    joint_direction = [-1, -1, 1, 1, 1, 1]
-    mass = [3.7000, 8.3930, 2.2750, 1.2190, 1.2190, 0.1879]
-    center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 0.0265], [0, -0.0018, 0.01634], [0, 0.0018,0.01634], [0, 0, -0.001159] ]
-  -->
-  <xacro:property name="ur5_d1" value="0.089159" />
-  <xacro:property name="ur5_a2" value="-0.42500" />
-  <xacro:property name="ur5_a3" value="-0.39225" />
-  <xacro:property name="ur5_d4" value="0.10915" />
-  <xacro:property name="ur5_d5" value="0.09465" />
-  <xacro:property name="ur5_d6" value="0.0823" />
-
-  <!-- Arbitrary offsets for shoulder/elbow joints -->
-  <xacro:property name="ur5_shoulder_offset" value="0.13585" />  <!-- measured from model -->
-  <xacro:property name="ur5_elbow_offset" value="-0.1197" /> <!-- measured from model -->
-
-  <!-- link lengths used in model -->
-  <xacro:property name="ur5_shoulder_height" value="${ur5_d1}" />
-  <xacro:property name="ur5_upper_arm_length" value="${-ur5_a2}" />
-  <xacro:property name="ur5_forearm_length" value="${-ur5_a3}" />
-  <xacro:property name="ur5_wrist_1_length" value="${ur5_d4 - ur5_elbow_offset - ur5_shoulder_offset}" />
-  <xacro:property name="ur5_wrist_2_length" value="${ur5_d5}" />
-  <xacro:property name="ur5_wrist_3_length" value="${ur5_d6}" />
-  <!--property name="ur5_shoulder_height" value="0.089159" /-->
-  <!--property name="ur5_shoulder_offset" value="0.13585" /-->  <!-- ur5_shoulder_offset - ur5_elbow_offset + ur5_wrist_1_length = 0.10915 -->
-  <!--property name="ur5_upper_arm_length" value="0.42500" /-->
-  <!--property name="ur5_elbow_offset" value="0.1197" /-->       <!-- CAD measured -->
-  <!--property name="ur5_forearm_length" value="0.39225" /-->
-  <!--property name="ur5_wrist_1_length" value="0.093" /-->     <!-- CAD measured -->
-  <!--property name="ur5_wrist_2_length" value="0.09465" /-->   <!-- In CAD this distance is 0.930, but in the spec it is 0.09465 -->
-  <!--property name="ur5_wrist_3_length" value="0.0823" /-->
-
-  <xacro:property name="ur5_shoulder_radius" value="0.060" />   <!-- manually measured -->
-  <xacro:property name="ur5_upper_arm_radius" value="0.054" />  <!-- manually measured -->
-  <xacro:property name="ur5_elbow_radius" value="0.060" />      <!-- manually measured -->
-  <xacro:property name="ur5_forearm_radius" value="0.040" />    <!-- manually measured -->
-  <xacro:property name="ur5_wrist_radius" value="0.045" />      <!-- manually measured -->
-
   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
     <inertial>
       <mass value="${mass}" />
@@ -75,7 +14,6 @@
     </inertial>
   </xacro:macro>
 
-
   <xacro:macro name="ur5_robot" params="prefix joint_limited
      shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
      shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
@@ -83,6 +21,68 @@
      wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
      wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
      wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}">
+
+    <!-- Inertia parameters -->
+    <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
+    <xacro:property name="shoulder_mass" value="3.7000" />
+    <xacro:property name="upper_arm_mass" value="8.3930" />
+    <xacro:property name="forearm_mass" value="2.2750" />
+    <xacro:property name="wrist_1_mass" value="1.2190" />
+    <xacro:property name="wrist_2_mass" value="1.2190" />
+    <xacro:property name="wrist_3_mass" value="0.1879" />
+
+    <xacro:property name="shoulder_cog" value="0.0 0.00193 -0.02561" />
+    <xacro:property name="upper_arm_cog" value="0.0 -0.024201 0.2125" />
+    <xacro:property name="forearm_cog" value="0.0 0.0265 0.11993" />
+    <xacro:property name="wrist_1_cog" value="0.0 0.110949 0.01634" />
+    <xacro:property name="wrist_2_cog" value="0.0 0.0018 0.11099" />
+    <xacro:property name="wrist_3_cog" value="0.0 0.001159 0.0" />
+
+    <!-- Kinematic model -->
+    <!-- Properties from urcontrol.conf -->
+    <!--
+      DH for UR5:
+      a = [0.00000, -0.42500, -0.39225,  0.00000,  0.00000,  0.0000]
+      d = [0.089159,  0.00000,  0.00000,  0.10915,  0.09465,  0.0823]
+      alpha = [ 1.570796327, 0, 0, 1.570796327, -1.570796327, 0 ]
+      q_home_offset = [0, -1.570796327, 0, -1.570796327, 0, 0]
+      joint_direction = [-1, -1, 1, 1, 1, 1]
+      mass = [3.7000, 8.3930, 2.2750, 1.2190, 1.2190, 0.1879]
+      center_of_mass = [ [0, -0.02561, 0.00193], [0.2125, 0, 0.11336], [0.11993, 0.0, 0.0265], [0, -0.0018, 0.01634], [0, 0.0018,0.01634], [0, 0, -0.001159] ]
+    -->
+    <xacro:property name="d1" value="0.089159" />
+    <xacro:property name="a2" value="-0.42500" />
+    <xacro:property name="a3" value="-0.39225" />
+    <xacro:property name="d4" value="0.10915" />
+    <xacro:property name="d5" value="0.09465" />
+    <xacro:property name="d6" value="0.0823" />
+
+    <!-- Arbitrary offsets for shoulder/elbow joints -->
+    <xacro:property name="shoulder_offset" value="0.13585" />  <!-- measured from model -->
+    <xacro:property name="elbow_offset" value="-0.1197" /> <!-- measured from model -->
+
+    <!-- link lengths used in model -->
+    <xacro:property name="shoulder_height" value="${d1}" />
+    <xacro:property name="upper_arm_length" value="${-a2}" />
+    <xacro:property name="forearm_length" value="${-a3}" />
+    <xacro:property name="wrist_1_length" value="${d4 - elbow_offset - shoulder_offset}" />
+    <xacro:property name="wrist_2_length" value="${d5}" />
+    <xacro:property name="wrist_3_length" value="${d6}" />
+    <!--property name="shoulder_height" value="0.089159" /-->
+    <!--property name="shoulder_offset" value="0.13585" /-->  <!-- shoulder_offset - elbow_offset + wrist_1_length = 0.10915 -->
+    <!--property name="upper_arm_length" value="0.42500" /-->
+    <!--property name="elbow_offset" value="0.1197" /-->       <!-- CAD measured -->
+    <!--property name="forearm_length" value="0.39225" /-->
+    <!--property name="wrist_1_length" value="0.093" /-->     <!-- CAD measured -->
+    <!--property name="wrist_2_length" value="0.09465" /-->   <!-- In CAD this distance is 0.930, but in the spec it is 0.09465 -->
+    <!--property name="wrist_3_length" value="0.0823" /-->
+
+    <xacro:property name="shoulder_radius" value="0.060" />   <!-- manually measured -->
+    <xacro:property name="upper_arm_radius" value="0.054" />  <!-- manually measured -->
+    <xacro:property name="elbow_radius" value="0.060" />      <!-- manually measured -->
+    <xacro:property name="forearm_radius" value="0.040" />    <!-- manually measured -->
+    <xacro:property name="wrist_radius" value="0.045" />      <!-- manually measured -->
+
 
     <link name="${prefix}base_link" >
       <visual>
@@ -98,7 +98,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/base.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.05" mass="${ur5_base_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.05" mass="${base_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -106,7 +106,7 @@
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link" />
       <child link = "${prefix}shoulder_link" />
-      <origin xyz="0.0 0.0 ${ur5_shoulder_height}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="3.15"/>
@@ -131,7 +131,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/shoulder.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.15" mass="${ur5_shoulder_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.15" mass="${shoulder_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -139,7 +139,7 @@
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
-      <origin xyz="0.0 ${ur5_shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="3.15"/>
@@ -164,7 +164,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/upperarm.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.56" mass="${ur5_upper_arm_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.56" mass="${upper_arm_mass}">
         <origin xyz="0.0 0.0 0.28" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -172,7 +172,7 @@
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
-      <origin xyz="0.0 ${ur5_elbow_offset} ${ur5_upper_arm_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.15"/>
@@ -197,7 +197,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/forearm.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.5" mass="${ur5_forearm_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.5" mass="${forearm_mass}">
         <origin xyz="0.0 0.0 0.25" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -205,7 +205,7 @@
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
       <child link = "${prefix}wrist_1_link" />
-      <origin xyz="0.0 0.0 ${ur5_forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="28.0" velocity="3.2"/>
@@ -230,7 +230,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/wrist1.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${ur5_wrist_1_mass}">
+      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${wrist_1_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -238,7 +238,7 @@
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
-      <origin xyz="0.0 ${ur5_wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="28.0" velocity="3.2"/>
@@ -263,7 +263,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/wrist2.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${ur5_wrist_2_mass}">
+      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${wrist_2_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -271,7 +271,7 @@
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
-      <origin xyz="0.0 0.0 ${ur5_wrist_2_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="28.0" velocity="3.2"/>
@@ -296,7 +296,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/wrist3.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${ur5_wrist_3_mass}">
+      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${wrist_3_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -304,7 +304,7 @@
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />
       <child link = "${prefix}ee_link" />
-      <origin xyz="0.0 ${ur5_wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
+      <origin xyz="0.0 ${wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
     </joint>
 
     <link name="${prefix}ee_link">
@@ -334,7 +334,7 @@
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}wrist_3_link-tool0_fixed_joint" type="fixed">
-      <origin xyz="0 ${ur5_wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
+      <origin xyz="0 ${wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
       <parent link="${prefix}wrist_3_link"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/ur_description/urdf/ur5.urdf.xacro
+++ b/ur_description/urdf/ur5.urdf.xacro
@@ -5,20 +5,20 @@
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />
 
   <!-- Inertia parameters -->
-  <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
-  <xacro:property name="shoulder_mass" value="3.7000" />
-  <xacro:property name="upper_arm_mass" value="8.3930" />
-  <xacro:property name="forearm_mass" value="2.2750" />
-  <xacro:property name="wrist_1_mass" value="1.2190" />
-  <xacro:property name="wrist_2_mass" value="1.2190" />
-  <xacro:property name="wrist_3_mass" value="0.1879" />
+  <xacro:property name="ur5_base_mass" value="4.0" />  <!-- This mass might be incorrect -->
+  <xacro:property name="ur5_shoulder_mass" value="3.7000" />
+  <xacro:property name="ur5_upper_arm_mass" value="8.3930" />
+  <xacro:property name="ur5_forearm_mass" value="2.2750" />
+  <xacro:property name="ur5_wrist_1_mass" value="1.2190" />
+  <xacro:property name="ur5_wrist_2_mass" value="1.2190" />
+  <xacro:property name="ur5_wrist_3_mass" value="0.1879" />
 
-  <xacro:property name="shoulder_cog" value="0.0 0.00193 -0.02561" />
-  <xacro:property name="upper_arm_cog" value="0.0 -0.024201 0.2125" />
-  <xacro:property name="forearm_cog" value="0.0 0.0265 0.11993" />
-  <xacro:property name="wrist_1_cog" value="0.0 0.110949 0.01634" />
-  <xacro:property name="wrist_2_cog" value="0.0 0.0018 0.11099" />
-  <xacro:property name="wrist_3_cog" value="0.0 0.001159 0.0" />
+  <xacro:property name="ur5_shoulder_cog" value="0.0 0.00193 -0.02561" />
+  <xacro:property name="ur5_upper_arm_cog" value="0.0 -0.024201 0.2125" />
+  <xacro:property name="ur5_forearm_cog" value="0.0 0.0265 0.11993" />
+  <xacro:property name="ur5_wrist_1_cog" value="0.0 0.110949 0.01634" />
+  <xacro:property name="ur5_wrist_2_cog" value="0.0 0.0018 0.11099" />
+  <xacro:property name="ur5_wrist_3_cog" value="0.0 0.001159 0.0" />
 
   <!-- Kinematic model -->
   <!-- Properties from urcontrol.conf -->
@@ -40,30 +40,30 @@
   <xacro:property name="ur5_d6" value="0.0823" />
 
   <!-- Arbitrary offsets for shoulder/elbow joints -->
-  <xacro:property name="shoulder_offset" value="0.13585" />  <!-- measured from model -->
-  <xacro:property name="elbow_offset" value="-0.1197" /> <!-- measured from model -->
+  <xacro:property name="ur5_shoulder_offset" value="0.13585" />  <!-- measured from model -->
+  <xacro:property name="ur5_elbow_offset" value="-0.1197" /> <!-- measured from model -->
 
   <!-- link lengths used in model -->
-  <xacro:property name="shoulder_height" value="${ur5_d1}" />
-  <xacro:property name="upper_arm_length" value="${-ur5_a2}" />
-  <xacro:property name="forearm_length" value="${-ur5_a3}" />
-  <xacro:property name="wrist_1_length" value="${ur5_d4 - elbow_offset - shoulder_offset}" />
-  <xacro:property name="wrist_2_length" value="${ur5_d5}" />
-  <xacro:property name="wrist_3_length" value="${ur5_d6}" />
-  <!--property name="shoulder_height" value="0.089159" /-->
-  <!--property name="shoulder_offset" value="0.13585" /-->  <!-- shoulder_offset - elbow_offset + wrist_1_length = 0.10915 -->
-  <!--property name="upper_arm_length" value="0.42500" /-->
-  <!--property name="elbow_offset" value="0.1197" /-->       <!-- CAD measured -->
-  <!--property name="forearm_length" value="0.39225" /-->
-  <!--property name="wrist_1_length" value="0.093" /-->     <!-- CAD measured -->
-  <!--property name="wrist_2_length" value="0.09465" /-->   <!-- In CAD this distance is 0.930, but in the spec it is 0.09465 -->
-  <!--property name="wrist_3_length" value="0.0823" /-->
+  <xacro:property name="ur5_shoulder_height" value="${ur5_d1}" />
+  <xacro:property name="ur5_upper_arm_length" value="${-ur5_a2}" />
+  <xacro:property name="ur5_forearm_length" value="${-ur5_a3}" />
+  <xacro:property name="ur5_wrist_1_length" value="${ur5_d4 - ur5_elbow_offset - ur5_shoulder_offset}" />
+  <xacro:property name="ur5_wrist_2_length" value="${ur5_d5}" />
+  <xacro:property name="ur5_wrist_3_length" value="${ur5_d6}" />
+  <!--property name="ur5_shoulder_height" value="0.089159" /-->
+  <!--property name="ur5_shoulder_offset" value="0.13585" /-->  <!-- ur5_shoulder_offset - ur5_elbow_offset + ur5_wrist_1_length = 0.10915 -->
+  <!--property name="ur5_upper_arm_length" value="0.42500" /-->
+  <!--property name="ur5_elbow_offset" value="0.1197" /-->       <!-- CAD measured -->
+  <!--property name="ur5_forearm_length" value="0.39225" /-->
+  <!--property name="ur5_wrist_1_length" value="0.093" /-->     <!-- CAD measured -->
+  <!--property name="ur5_wrist_2_length" value="0.09465" /-->   <!-- In CAD this distance is 0.930, but in the spec it is 0.09465 -->
+  <!--property name="ur5_wrist_3_length" value="0.0823" /-->
 
-  <xacro:property name="shoulder_radius" value="0.060" />   <!-- manually measured -->
-  <xacro:property name="upper_arm_radius" value="0.054" />  <!-- manually measured -->
-  <xacro:property name="elbow_radius" value="0.060" />      <!-- manually measured -->
-  <xacro:property name="forearm_radius" value="0.040" />    <!-- manually measured -->
-  <xacro:property name="wrist_radius" value="0.045" />      <!-- manually measured -->
+  <xacro:property name="ur5_shoulder_radius" value="0.060" />   <!-- manually measured -->
+  <xacro:property name="ur5_upper_arm_radius" value="0.054" />  <!-- manually measured -->
+  <xacro:property name="ur5_elbow_radius" value="0.060" />      <!-- manually measured -->
+  <xacro:property name="ur5_forearm_radius" value="0.040" />    <!-- manually measured -->
+  <xacro:property name="ur5_wrist_radius" value="0.045" />      <!-- manually measured -->
 
   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
     <inertial>
@@ -98,7 +98,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/base.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.05" mass="${base_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.05" mass="${ur5_base_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -106,7 +106,7 @@
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
       <parent link="${prefix}base_link" />
       <child link = "${prefix}shoulder_link" />
-      <origin xyz="0.0 0.0 ${shoulder_height}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${ur5_shoulder_height}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="3.15"/>
@@ -131,7 +131,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/shoulder.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.15" mass="${shoulder_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.15" mass="${ur5_shoulder_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -139,7 +139,7 @@
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
-      <origin xyz="0.0 ${shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 ${ur5_shoulder_offset} 0.0" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="150.0" velocity="3.15"/>
@@ -164,7 +164,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/upperarm.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.56" mass="${upper_arm_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.56" mass="${ur5_upper_arm_mass}">
         <origin xyz="0.0 0.0 0.28" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -172,7 +172,7 @@
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
-      <origin xyz="0.0 ${elbow_offset} ${upper_arm_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${ur5_elbow_offset} ${ur5_upper_arm_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-pi}" upper="${pi}" effort="150.0" velocity="3.15"/>
@@ -197,7 +197,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/forearm.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.06" length="0.5" mass="${forearm_mass}">
+      <xacro:cylinder_inertial radius="0.06" length="0.5" mass="${ur5_forearm_mass}">
         <origin xyz="0.0 0.0 0.25" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -205,7 +205,7 @@
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
       <child link = "${prefix}wrist_1_link" />
-      <origin xyz="0.0 0.0 ${forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
+      <origin xyz="0.0 0.0 ${ur5_forearm_length}" rpy="0.0 ${pi / 2.0} 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="28.0" velocity="3.2"/>
@@ -230,7 +230,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/wrist1.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${wrist_1_mass}">
+      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${ur5_wrist_1_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -238,7 +238,7 @@
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
-      <origin xyz="0.0 ${wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 ${ur5_wrist_1_length} 0.0" rpy="0.0 0.0 0.0" />
       <axis xyz="0 0 1" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="28.0" velocity="3.2"/>
@@ -263,7 +263,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/wrist2.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${wrist_2_mass}">
+      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${ur5_wrist_2_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -271,7 +271,7 @@
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
-      <origin xyz="0.0 0.0 ${wrist_2_length}" rpy="0.0 0.0 0.0" />
+      <origin xyz="0.0 0.0 ${ur5_wrist_2_length}" rpy="0.0 0.0 0.0" />
       <axis xyz="0 1 0" />
       <xacro:unless value="${joint_limited}">
         <limit lower="${-2.0 * pi}" upper="${2.0 * pi}" effort="28.0" velocity="3.2"/>
@@ -296,7 +296,7 @@
           <mesh filename="package://ur_description/meshes/ur5/collision/wrist3.stl" />
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${wrist_3_mass}">
+      <xacro:cylinder_inertial radius="0.6" length="0.12" mass="${ur5_wrist_3_mass}">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
@@ -304,7 +304,7 @@
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />
       <child link = "${prefix}ee_link" />
-      <origin xyz="0.0 ${wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
+      <origin xyz="0.0 ${ur5_wrist_3_length} 0.0" rpy="0.0 0.0 ${pi/2.0}" />
     </joint>
 
     <link name="${prefix}ee_link">
@@ -334,7 +334,7 @@
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}wrist_3_link-tool0_fixed_joint" type="fixed">
-      <origin xyz="0 ${wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
+      <origin xyz="0 ${ur5_wrist_3_length} 0" rpy="${pi/-2.0} 0 0"/>
       <parent link="${prefix}wrist_3_link"/>
       <child link="${prefix}tool0"/>
     </joint>


### PR DESCRIPTION
Uploading multiple different UR definitions currently breaks the previous robot definitions by overwriting their link lengths and other parameters. This commit makes the property names for each robot model unique so they are independent of the others.

See the before and after pictures in Gazebo below. The UR5 was the last model to be loaded in the scene definition, so the link lengths of the UR3 have become too long, and those of the UR10 too short. 

![gazebo-before](https://user-images.githubusercontent.com/4535737/41693266-7d51b672-753f-11e8-8b55-25c9afa58f10.png)

![gazebo-after](https://user-images.githubusercontent.com/4535737/41693269-80456bb2-753f-11e8-9a6c-efc7eb2163e6.png)

I don't think this change affects anything outside of these files and I have had no problems using it in our own development.