### PR TITLE
MoveGroupExecuteService is Deprecated by MoveIt!

### DIFF
--- a/ur10_moveit_config/launch/move_group.launch
+++ b/ur10_moveit_config/launch/move_group.launch
@@ -50,7 +50,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/ur3_moveit_config/launch/move_group.launch
+++ b/ur3_moveit_config/launch/move_group.launch
@@ -51,7 +51,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/ur5_moveit_config/launch/move_group.launch
+++ b/ur5_moveit_config/launch/move_group.launch
@@ -50,7 +50,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction


### PR DESCRIPTION
Replace MoveGroupExecuteService with MoveGroupExecuteTrajectoryAction following the warning.