### PR TITLE
Add transmission_hw_interface to UR xacro and expose everywhere

### DIFF
--- a/ur_description/launch/ur10_upload.launch
+++ b/ur_description/launch/ur10_upload.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="limited" default="false" doc="If true, limits joint range [-PI, PI] on all joints." />
-  
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
+  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
 </launch>

--- a/ur_description/launch/ur3_upload.launch
+++ b/ur_description/launch/ur3_upload.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="limited" default="false" doc="If true, limits joint range [-PI, PI] on all joints." />
-  
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur3_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur3_joint_limited_robot.urdf.xacro'" />
+  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur3_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur3_joint_limited_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
 </launch>

--- a/ur_description/launch/ur5_upload.launch
+++ b/ur_description/launch/ur5_upload.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="limited" default="false" doc="If true, limits joint range [-PI, PI] on all joints." />
-  
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
+  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
 </launch>

--- a/ur_description/urdf/ur.transmission.xacro
+++ b/ur_description/urdf/ur.transmission.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="ur_arm_transmission" params="prefix">
+  <xacro:macro name="ur_arm_transmission" params="prefix hw_interface">
 
     <transmission name="${prefix}shoulder_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_pan_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_pan_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -16,7 +16,7 @@
     <transmission name="${prefix}shoulder_lift_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_lift_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_lift_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -26,7 +26,7 @@
     <transmission name="${prefix}elbow_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}elbow_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}elbow_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -36,7 +36,7 @@
     <transmission name="${prefix}wrist_1_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_1_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_1_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -46,7 +46,7 @@
     <transmission name="${prefix}wrist_2_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_2_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_2_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -56,7 +56,7 @@
     <transmission name="${prefix}wrist_3_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_3_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_3_motor">
         <mechanicalReduction>1</mechanicalReduction>

--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -20,12 +20,13 @@
   </xacro:macro>
 
   <xacro:macro name="ur10_robot" params="prefix joint_limited
-		 shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
-		 shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
-		 elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
-		 wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
-		 wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
-		 wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}">
+    shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
+    shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
+    elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
+    wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
+    wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
+    wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}
+    transmission_hw_interface:=hardware_interface/PositionJointInterface">
 
     <!-- Inertia parameters -->
     <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
@@ -300,7 +301,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
     <!-- ROS base_link to UR 'Base' Coordinates transform -->

--- a/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur10" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_description)/urdf/common.gazebo.xacro" />
 
@@ -10,12 +12,13 @@
 
   <!-- arm -->
   <xacro:ur10_robot prefix="" joint_limited="true"
-		 shoulder_pan_lower_limit="${-pi}" shoulder_pan_upper_limit="${pi}"
-		 shoulder_lift_lower_limit="${-pi}" shoulder_lift_upper_limit="${pi}"
-		 elbow_joint_lower_limit="${-pi}" elbow_joint_upper_limit="${pi}"
-		 wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
-		 wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
-		 wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+    shoulder_pan_lower_limit="${-pi}" shoulder_pan_upper_limit="${pi}"
+    shoulder_lift_lower_limit="${-pi}" shoulder_lift_upper_limit="${pi}"
+    elbow_joint_lower_limit="${-pi}" elbow_joint_upper_limit="${pi}"
+    wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
+    wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
+    wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
 />
 
   <link name="world" />

--- a/ur_description/urdf/ur10_robot.urdf.xacro
+++ b/ur_description/urdf/ur10_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur10" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_description)/urdf/common.gazebo.xacro" />
 
@@ -9,7 +11,9 @@
   <xacro:include filename="$(find ur_description)/urdf/ur10.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:ur10_robot prefix="" joint_limited="false"/>
+  <xacro:ur10_robot prefix="" joint_limited="false"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+  />
 
   <link name="world" />
 

--- a/ur_description/urdf/ur3.urdf.xacro
+++ b/ur_description/urdf/ur3.urdf.xacro
@@ -19,12 +19,13 @@
   </xacro:macro>
 
   <xacro:macro name="ur3_robot" params="prefix joint_limited
-     shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
-     shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
-     elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
-     wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
-     wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
-     wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}">
+    shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
+    shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
+    elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
+    wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
+    wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
+    wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}
+    transmission_hw_interface:=hardware_interface/PositionJointInterface">
 
     <!-- Inertia parameters -->
     <xacro:property name="base_mass" value="2.0" />  <!-- This mass might be incorrect -->
@@ -299,7 +300,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
     <!-- ROS base_link to UR 'Base' Coordinates transform -->

--- a/ur_description/urdf/ur3_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur3_joint_limited_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur3" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_description)/urdf/common.gazebo.xacro" />
 
@@ -16,6 +18,7 @@
     wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
     wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
     wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
   />
 
   <link name="world" />

--- a/ur_description/urdf/ur3_robot.urdf.xacro
+++ b/ur_description/urdf/ur3_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur3" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_description)/urdf/common.gazebo.xacro" />
 
@@ -9,7 +11,9 @@
   <xacro:include filename="$(find ur_description)/urdf/ur3.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:ur3_robot prefix="" joint_limited="false"/>
+  <xacro:ur3_robot prefix="" joint_limited="false"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+  />
 
   <link name="world" />
 

--- a/ur_description/urdf/ur5.urdf.xacro
+++ b/ur_description/urdf/ur5.urdf.xacro
@@ -15,12 +15,13 @@
   </xacro:macro>
 
   <xacro:macro name="ur5_robot" params="prefix joint_limited
-     shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
-     shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
-     elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
-     wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
-     wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
-     wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}">
+    shoulder_pan_lower_limit:=${-pi}    shoulder_pan_upper_limit:=${pi}
+    shoulder_lift_lower_limit:=${-pi}    shoulder_lift_upper_limit:=${pi}
+    elbow_joint_lower_limit:=${-pi}    elbow_joint_upper_limit:=${pi}
+    wrist_1_lower_limit:=${-pi}    wrist_1_upper_limit:=${pi}
+    wrist_2_lower_limit:=${-pi}    wrist_2_upper_limit:=${pi}
+    wrist_3_lower_limit:=${-pi}    wrist_3_upper_limit:=${pi}
+    transmission_hw_interface:=hardware_interface/PositionJointInterface">
 
     <!-- Inertia parameters -->
     <xacro:property name="base_mass" value="4.0" />  <!-- This mass might be incorrect -->
@@ -316,7 +317,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
     <!-- ROS base_link to UR 'Base' Coordinates transform -->

--- a/ur_description/urdf/ur5_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur5_joint_limited_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur5" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_description)/urdf/common.gazebo.xacro" />
 
@@ -16,6 +18,7 @@
     wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
     wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
     wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
   />
 
   <link name="world" />

--- a/ur_description/urdf/ur5_robot.urdf.xacro
+++ b/ur_description/urdf/ur5_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur5" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_description)/urdf/common.gazebo.xacro" />
 
@@ -9,7 +11,9 @@
   <xacro:include filename="$(find ur_description)/urdf/ur5.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:ur5_robot prefix="" joint_limited="false"/>
+  <xacro:ur5_robot prefix="" joint_limited="false"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+  />
 
   <link name="world" />
 


### PR DESCRIPTION
Adds the capability to select the hardware interface used in the `<transmission>` elements in the URDF model. This allows creating custom simulation setups with different hardware interfaces, e.g. `hardware_interface/VelocityJointInterface`.

One thing I'm not very happy about is repeating the default value in so many places, but I cannot see a way around this to maintain backwards compatibility for users that use the different bits in this repo: e.g. users of the default `ur10_robot.urdf.xacro` vs users that compose other models using the macro itself.

There's also some whitespace changes. Let me know if you prefer I maintain the original lines.