### PR TITLE
Updated xacro namespace.

### DIFF
--- a/ur_description/urdf/common.gazebo.xacro
+++ b/ur_description/urdf/common.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
   <gazebo>
     <plugin name="ros_control" filename="libgazebo_ros_control.so">

--- a/ur_description/urdf/ur.gazebo.xacro
+++ b/ur_description/urdf/ur.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
   <xacro:macro name="ur_arm_gazebo" params="prefix">
 

--- a/ur_description/urdf/ur.transmission.xacro
+++ b/ur_description/urdf/ur.transmission.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
   <xacro:macro name="ur_arm_transmission" params="prefix">
 

--- a/ur_description/urdf/ur10.urdf.xacro
+++ b/ur_description/urdf/ur10.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
 <!--
   Author: Kelsey Hawkins

--- a/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur10_joint_limited_robot.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
+<robot xmlns:xacro="http://wiki.ros.org/xacro"
        name="ur10" >
 
   <!-- common stuff -->

--- a/ur_description/urdf/ur10_robot.urdf.xacro
+++ b/ur_description/urdf/ur10_robot.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
+<robot xmlns:xacro="http://wiki.ros.org/xacro"
        name="ur10" >
 
   <!-- common stuff -->

--- a/ur_description/urdf/ur3.urdf.xacro
+++ b/ur_description/urdf/ur3.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
 <!--
   Author: Felix Messmer

--- a/ur_description/urdf/ur3_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur3_joint_limited_robot.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
+<robot xmlns:xacro="http://wiki.ros.org/xacro"
        name="ur3" >
 
   <!-- common stuff -->

--- a/ur_description/urdf/ur3_robot.urdf.xacro
+++ b/ur_description/urdf/ur3_robot.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
+<robot xmlns:xacro="http://wiki.ros.org/xacro"
        name="ur3" >
 
   <!-- common stuff -->

--- a/ur_description/urdf/ur5.urdf.xacro
+++ b/ur_description/urdf/ur5.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
   <xacro:include filename="$(find ur_description)/urdf/ur.transmission.xacro" />
   <xacro:include filename="$(find ur_description)/urdf/ur.gazebo.xacro" />

--- a/ur_description/urdf/ur5_joint_limited_robot.urdf.xacro
+++ b/ur_description/urdf/ur5_joint_limited_robot.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
+<robot xmlns:xacro="http://wiki.ros.org/xacro"
        name="ur5" >
 
   <!-- common stuff -->

--- a/ur_description/urdf/ur5_robot.urdf.xacro
+++ b/ur_description/urdf/ur5_robot.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro"
+<robot xmlns:xacro="http://wiki.ros.org/xacro"
        name="ur5" >
 
   <!-- common stuff -->


### PR DESCRIPTION
Use new namespace to avoid _inconsistent namespace redifinitions for xmlns:xacro_ warnings.