### PR TITLE
removed non-existent moveit KDL libraries from ur_kinematics includes

### DIFF
--- a/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
+++ b/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
@@ -94,8 +94,6 @@
 #include <kdl/chainiksolvervel_pinv.hpp>
 #include <kdl/chainiksolverpos_nr_jl.hpp>
 #include <kdl/chainfksolverpos_recursive.hpp>
-#include <moveit/kdl_kinematics_plugin/chainiksolver_pos_nr_jl_mimic.hpp>
-#include <moveit/kdl_kinematics_plugin/chainiksolver_vel_pinv_mimic.hpp>
 #include <moveit/kdl_kinematics_plugin/joint_mimic.hpp>
 
 // MoveIt!


### PR DESCRIPTION
Per [this moveit issue](https://github.com/ros-planning/moveit/issues/1351) it seems that #403 should be handled by removing these includes. This is a PR removes the non-existend KDL headers from the ur_kinematics includes so that this builds on melodic.