### PR TITLE
[Gazebo] Add (but commented) the pid parameters for the position controller

### DIFF
--- a/ur_description/urdf/common.gazebo.xacro
+++ b/ur_description/urdf/common.gazebo.xacro
@@ -3,8 +3,8 @@
 
   <gazebo>
     <plugin name="ros_control" filename="libgazebo_ros_control.so">
-      <!--robotNamespace>/</robotNamespace-->
       <!--robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType-->
+      <legacyModeNS>true</legacyModeNS>
     </plugin>
 
 <!--

--- a/ur_gazebo/controller/arm_controller_ur10.yaml
+++ b/ur_gazebo/controller/arm_controller_ur10.yaml
@@ -29,3 +29,14 @@ joint_group_position_controller:
      - wrist_2_joint
      - wrist_3_joint
 
+#Although Gazebo 7 requires the defition of the pid parameters for a the position controller, this is not working. 
+#Please uncomment the following lines for Gazebo or gazebo_ros_control upgrades
+
+#gazebo_ros_control:
+#  pid_gains:
+#    shoulder_pan_joint: {p: 20.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#    shoulder_lift_joint: {p: 20.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#    elbow_joint: {p: 20.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#    wrist_1_joint: {p: 20.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#    wrist_2_joint: {p: 20.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#    wrist_3_joint: {p: 20.0,  i: 0.0, d: 0.1, i_clamp: 1}

--- a/ur_gazebo/controller/arm_controller_ur3.yaml
+++ b/ur_gazebo/controller/arm_controller_ur3.yaml
@@ -29,3 +29,15 @@ joint_group_position_controller:
      - wrist_2_joint
      - wrist_3_joint
 
+
+#Although Gazebo 7 requires the defition of the pid parameters for a the position controller, this is not working. 
+#Please uncomment the following lines for Gazebo or gazebo_ros_control upgrades
+
+#gazebo_ros_control:
+#  pid_gains:
+#      shoulder_pan_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#      shoulder_lift_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#      elbow_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#      wrist_1_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#      wrist_2_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
+#      wrist_3_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}

--- a/ur_gazebo/controller/arm_controller_ur5.yaml
+++ b/ur_gazebo/controller/arm_controller_ur5.yaml
@@ -29,3 +29,14 @@ joint_group_position_controller:
      - wrist_2_joint
      - wrist_3_joint
 
+#Although Gazebo 7 requires the defition of the pid parameters for a the position controller, this is not working. 
+#Please uncomment the following lines for Gazebo or gazebo_ros_control upgrades
+
+#gazebo_ros_control:
+#  pid_gains:
+#    shoulder_pan_joint: {p: 1.2,  i: 0.0, d: 0.1, i_clamp: 1}
+#    shoulder_lift_joint: {p: 1.2,  i: 0.0, d: 0.1, i_clamp: 1}
+#    elbow_joint: {p: 1.2,  i: 0.0, d: 0.1, i_clamp: 1}
+#    wrist_1_joint: {p: 1.2,  i: 0.0, d: 0.1, i_clamp: 1}
+#    wrist_2_joint: {p: 1.2,  i: 0.0, d: 0.1, i_clamp: 1}
+#    wrist_3_joint: {p: 1.2,  i: 0.0, d: 0.1, i_clamp: 1}


### PR DESCRIPTION
Currently the Gazebo simulation, although everything is working perfectly,  pops up the following erros/warnings:

```
[ERROR] [1562314333.213958955, 0.341000000]: GazeboRosControlPlugin missing <legacyModeNS> while using DefaultRobotHWSim, defaults to true.
This setting assumes you have an old package with an old implementation of DefaultRobotHWSim, where the robotNamespace is disregarded and absolute paths are used instead.
If you do not want to fix this issue in an old package just set <legacyModeNS> to true.

[ERROR] [1562314333.328514271, 0.341000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/shoulder_pan_joint
[ERROR] [1562314333.329583042, 0.341000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/shoulder_lift_joint
[ERROR] [1562314333.330642618, 0.341000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/elbow_joint
[ERROR] [1562314333.331618601, 0.341000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/wrist_1_joint
[ERROR] [1562314333.332616502, 0.341000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/wrist_2_joint
[ERROR] [1562314333.333662371, 0.341000000]: No p gain specified for pid.  Namespace: /gazebo_ros_control/pid_gains/wrist_3_joint

[ WARN] [1562314333.341661101, 0.342000000]: The default_robot_hw_sim plugin is using the Joint::SetPosition method without preserving the link velocity.
[ WARN] [1562314333.341687900, 0.342000000]: As a result, gravity will not be simulated correctly for your model.
[ WARN] [1562314333.341706822, 0.342000000]: Please set gazebo_pid parameters, switch to the VelocityJointInterface or EffortJointInterface, or upgrade to Gazebo 9.
[ WARN] [1562314333.341727976, 0.342000000]: For details, see https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612
```
The first error is fixed by this PR. Unfortunately  set of the pid gains for the position controller just break the arm and the controllers are not working at all. I tried implementing  an  `EffortJointInterface` (instead of position) but this is also not working.

Although gazebo shows errors the controllers are working, then I suggest to keep the lines but commented. Probably are useful in the future. 

(PID parameters taken from ur_moder_driver configuration e.g. https://github.com/ros-industrial/ur_modern_driver/blob/master/config/ur10_controllers.yaml#L76-L83 I tried also tunning them with the `dynamic_reconfigure`, I didn't find a combination that works)