### PR TITLE
Added a domain field to Analog.msg

### DIFF
--- a/ur_msgs/msg/Analog.msg
+++ b/ur_msgs/msg/Analog.msg
@@ -1,2 +1,6 @@
+uint8 VOLTAGE=0
+uint8 CURRENT=1
+
 uint8 pin
+uint8 domain # can be VOLTAGE or CURRENT
 float32 state


### PR DESCRIPTION
On UR robots the domain of analog in- and outputs can be configured.
The Analog.msg didn't cover this so far.