### PR TITLE
fix #466: fix loading e-series robot_description param

### DIFF
--- a/ur10_e_moveit_config/launch/planning_context.launch
+++ b/ur10_e_moveit_config/launch/planning_context.launch
@@ -8,8 +8,8 @@
 
   <!-- Load universal robot description format (URDF) -->
   <group if="$(arg load_robot_description)">
-    <param unless="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
-    <param if="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
+    <param unless="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur10e_robot.urdf.xacro'" />
+    <param if="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur10e_joint_limited_robot.urdf.xacro'" />
   </group>
 
   <!-- The semantic description that corresponds to the URDF -->

--- a/ur10_e_moveit_config/package.xml
+++ b/ur10_e_moveit_config/package.xml
@@ -25,7 +25,7 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <depend>ur_description</depend>
+  <depend>ur_e_description</depend>
 
   <test_depend>roslaunch</test_depend>
   <buildtool_depend>catkin</buildtool_depend>

--- a/ur3_e_moveit_config/launch/planning_context.launch
+++ b/ur3_e_moveit_config/launch/planning_context.launch
@@ -8,8 +8,8 @@
 
   <!-- Load universal robot description format (URDF) -->
   <group if="$(arg load_robot_description)">
-    <param unless="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur3_robot.urdf.xacro'" />
-    <param if="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur3_joint_limited_robot.urdf.xacro'" />
+    <param unless="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur3e_robot.urdf.xacro'" />
+    <param if="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur3e_joint_limited_robot.urdf.xacro'" />
   </group>
 
   <!-- The semantic description that corresponds to the URDF -->

--- a/ur3_e_moveit_config/package.xml
+++ b/ur3_e_moveit_config/package.xml
@@ -25,7 +25,7 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <depend>ur_description</depend>
+  <depend>ur_e_description</depend>
 
   <test_depend>roslaunch</test_depend>
   <buildtool_depend>catkin</buildtool_depend>

--- a/ur5_e_moveit_config/launch/planning_context.launch
+++ b/ur5_e_moveit_config/launch/planning_context.launch
@@ -8,8 +8,8 @@
 
   <!-- Load universal robot description format (URDF) -->
   <group if="$(arg load_robot_description)">
-    <param unless="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
-    <param if="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
+    <param unless="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur5e_robot.urdf.xacro'" />
+    <param if="$(arg limited)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur5e_joint_limited_robot.urdf.xacro'" />
   </group>
 
   <!-- The semantic description that corresponds to the URDF -->

--- a/ur5_e_moveit_config/package.xml
+++ b/ur5_e_moveit_config/package.xml
@@ -25,7 +25,7 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <depend>ur_description</depend>
+  <depend>ur_e_description</depend>
 
   <test_depend>roslaunch</test_depend>
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Fixed the usages of `ur_description` (and matching urdf names) for all the e-series moveit_config packages to point to the correct `ur_e_description` package.