### PR TITLE
Updated cog for ur16 how I understand the documentation

### DIFF
--- a/ur_description/config/ur10/physical_parameters.yaml
+++ b/ur_description/config/ur10/physical_parameters.yaml
@@ -53,26 +53,97 @@ inertia_parameters:
 
   center_of_mass:
     shoulder_cog:
-      x: 0.0
-      y: 0.00244
-      z: -0.037
+      x: 0.021      # model.x
+      y: -0.027     # -model.z
+      z: 0.0        # model.y
     upper_arm_cog:
-      x: 0.00001
-      y: 0.15061
-      z: 0.38757
+      x: -0.232     # model.x - upper_arm_length
+      y: 0.0        # model.y
+      z: 0.158      # model.z
     forearm_cog:
-      x: -0.00012
-      y: 0.06112
-      z: 0.1984
+      x: -0.3323    # model.x - forearm_length
+      y: 0.0        # model.y
+      z: 0.068      # model.z
     wrist_1_cog:
-      x: -0.00021
-      y: -0.00112
-      z: 0.02269
+      x: 0.0        # model.x
+      y: -0.018     # -model.z
+      z: 0.007      # model.y
     wrist_2_cog:
-      x: -0.00021
-      y: 0.00112
-      z: 0.002269
+      x: 0.0        # model.x
+      y: 0.018      # model.z
+      z: -0.007     # -model.y
     wrist_3_cog:
-      x: 0.0
-      y: -0.001156
-      z: -0.00149
+      x: 0.0        # model.x
+      y: 0          # model.y
+      z: -0.026     # model.z
+
+  rotation:
+    shoulder:
+      roll: 1.570796326794897
+      pitch: 0
+      yaw: 0
+    upper_arm:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    forearm:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_1:
+      roll: 1.570796326794897
+      pitch: 0
+      yaw: 0
+    wrist_2:
+      roll: -1.570796326794897
+      pitch: 0
+      yaw: 0
+    wrist_3:
+      roll: 0
+      pitch: 0
+      yaw: 0
+
+  # extracted from URSim
+  tensor:
+    shoulder:
+      ixx: 0.03408
+      ixy: 0.00002
+      ixz: -0.00425
+      iyy: 0.03529
+      iyz: 0.00008
+      izz: 0.02156
+    upper_arm:
+      ixx: 0.02814
+      ixy: 0.00005
+      ixz: -0.01561
+      iyy: 0.77068
+      iyz: 0.00002
+      izz: 0.76943
+    forearm:
+      ixx: 0.01014
+      ixy: 0.00008
+      ixz: 0.00916
+      iyy: 0.30928
+      iyz: 0.0
+      izz: 0.30646
+    wrist_1:
+      ixx: 0.00296
+      ixy: -0.00001
+      ixz: 0.0
+      iyy: 0.00222
+      iyz: -0.00024
+      izz: 0.00258
+    wrist_2:
+      ixx: 0.00296
+      ixy: -0.00001
+      ixz: 0.0
+      iyy: 0.00222
+      iyz: -0.00024
+      izz: 0.00258
+    wrist_3:
+      ixx: 0.00040
+      ixy: 0.0
+      ixz: 0.0
+      iyy: 0.00041
+      iyz: 0.0
+      izz: 0.00034

--- a/ur_description/config/ur10e/physical_parameters.yaml
+++ b/ur_description/config/ur10e/physical_parameters.yaml
@@ -53,26 +53,97 @@ inertia_parameters:
 
   center_of_mass:
     shoulder_cog:
-      x: 0.0
-      y: 0.00244
-      z: -0.037
+      x: 0.021      # model.x
+      y: -0.027     # -model.z
+      z: 0.0        # model.y
     upper_arm_cog:
-      x: 0.00001
-      y: 0.15061
-      z: 0.38757
+      x: -0.2327    # model.x - upper_arm_length
+      y: 0.0        # model.y
+      z: 0.158      # model.z
     forearm_cog:
-      x: -0.00012
-      y: 0.06112
-      z: 0.1984
+      x: -0.33155   # model.x - forearm_length
+      y: 0.0        # model.y
+      z: 0.068      # model.z
     wrist_1_cog:
-      x: -0.00021
-      y: -0.00112
-      z: 0.02269
+      x: 0.0        # model.x
+      y: -0.018     # -model.z
+      z: 0.007      # model.y
     wrist_2_cog:
-      x: -0.00021
-      y: 0.00112
-      z: 0.002269
+      x: 0.0        # model.x
+      y: 0.018      # model.z
+      z: -0.007     # -model.y
     wrist_3_cog:
-      x: 0.0
-      y: -0.001156
-      z: -0.00149
+      x: 0.0        # model.x
+      y: 0.0        # model.y
+      z: -0.026     # model.z
+
+  rotation:
+    shoulder:
+      roll: 1.570796326794897
+      pitch: 0
+      yaw: 0
+    upper_arm:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    forearm:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_1:
+      roll: 1.570796326794897
+      pitch: 0
+      yaw: 0
+    wrist_2:
+      roll: -1.570796326794897
+      pitch: 0
+      yaw: 0
+    wrist_3:
+      roll: 0
+      pitch: 0
+      yaw: 0
+
+  # extracted from URSim
+  tensor:
+    shoulder:
+      ixx: 0.03408
+      ixy: 0.00002
+      ixz: -0.00425
+      iyy: 0.03529
+      iyz: 0.00008
+      izz: 0.02156
+    upper_arm:
+      ixx: 0.02814
+      ixy: 0.00005
+      ixz: -0.01561
+      iyy: 0.77068
+      iyz: 0.00002
+      izz: 0.76943
+    forearm:
+      ixx: 0.01014
+      ixy: 0.00008
+      ixz: 0.00916
+      iyy: 0.30928
+      iyz: 0.0
+      izz: 0.30646
+    wrist_1:
+      ixx: 0.00296
+      ixy: -0.00001
+      ixz: 0.0
+      iyy: 0.00222
+      iyz: -0.00024
+      izz: 0.00258
+    wrist_2:
+      ixx: 0.00296
+      ixy: -0.00001
+      ixz: 0.0
+      iyy: 0.00222
+      iyz: -0.00024
+      izz: 0.00258
+    wrist_3:
+      ixx: 0.00040
+      ixy: 0.0
+      ixz: 0.0
+      iyy: 0.00041
+      iyz: 0.0
+      izz: 0.00034

--- a/ur_description/config/ur16e/physical_parameters.yaml
+++ b/ur_description/config/ur16e/physical_parameters.yaml
@@ -53,28 +53,28 @@ inertia_parameters:
       radius: 0.045
       length: 0.05
 
-  center_of_mass: # Adjusted manually
+  center_of_mass: # model referring to https://www.universal-robots.com/how-tos-and-faqs/faq/ur-faq/parameters-for-calculations-of-kinematics-and-dynamics-45257/
     shoulder_cog:
-      x: 0.0
-      y: 0.00244
-      z: -0.037
+      x: 0.0 # model.x
+      y: -0.030 # -model.z
+      z: -0.016 # model.y
     upper_arm_cog:
-      x: 0.00001
-      y: 0.15061
-      z: 0.38757
+      x: -0.1764 # model.x - upperarm_length
+      y: 0.0 # model.y
+      z: 0.16 # model.z
     forearm_cog:
-      x: -0.00012
-      y: 0.06112
-      z: 0.1984
+      x: -0.166 # model.x - forearm_length
+      y: 0.0 # model.y
+      z: 0.065 # model.z
     wrist_1_cog:
-      x: -0.00021
-      y: -0.00112
-      z: 0.02269
+      x: 0.0 # model.x
+      y: -0.011 # -model.z
+      z: -0.009 # model.y
     wrist_2_cog:
-      x: -0.00021
-      y: 0.00112
-      z: 0.002269
+      x: 0.0 # model.x
+      y: 0.012 # model.z
+      z: -0.018 # -model.y
     wrist_3_cog:
-      x: 0.0
-      y: -0.001156
-      z: -0.00149
+      x: 0.0 # model.x
+      y: 0.0 # model.y
+      z: -0.044 # model.z

--- a/ur_description/config/ur16e/physical_parameters.yaml
+++ b/ur_description/config/ur16e/physical_parameters.yaml
@@ -78,3 +78,74 @@ inertia_parameters:
       x: 0.0 # model.x
       y: 0.0 # model.y
       z: -0.044 # model.z
+
+  rotation:
+    shoulder:
+      roll: 1.570796326794897
+      pitch: 0
+      yaw: 0
+    upper_arm:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    forearm:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_1:
+      roll: 1.570796326794897
+      pitch: 0
+      yaw: 0
+    wrist_2:
+      roll: -1.570796326794897
+      pitch: 0
+      yaw: 0
+    wrist_3:
+      roll: 0
+      pitch: 0
+      yaw: 0
+
+  # extracted from URSim
+  tensor:
+    shoulder:
+      ixx: 0.03351
+      ixy: 0.00002
+      ixz: -0.00001
+      iyy: 0.03374
+      iyz: 0.00374
+      izz: 0.02100
+    upper_arm:
+      ixx: 0.02796
+      ixy: -0.00010
+      ixz: -0.00720
+      iyy: 0.47558
+      iyz: 0.00003
+      izz: 0.47635
+    forearm:
+      ixx: 0.01091
+      ixy: 0.00006
+      ixz: 0.01012
+      iyy: 0.12060
+      iyz: 0.00001
+      izz: 0.11714
+    wrist_1:
+      ixx: 0.00609
+      ixy: -0.00001
+      ixz: 0.0
+      iyy: 0.00245
+      iyz: 0.00083
+      izz: 0.00579
+    wrist_2:
+      ixx: 0.00389
+      ixy: 0.00001
+      ixz: 0.0
+      iyy: 0.00219
+      iyz: -0.00045
+      izz: 0.00363
+    wrist_3:
+      ixx: 0.00117
+      ixy: 0.0
+      ixz: 0.0
+      iyy: 0.00118
+      iyz: 0.0
+      izz: 0.00084

--- a/ur_description/config/ur3/physical_parameters.yaml
+++ b/ur_description/config/ur3/physical_parameters.yaml
@@ -53,26 +53,97 @@ inertia_parameters:
 
   center_of_mass:
     shoulder_cog:
-      x: 0.0
-      y: -0.02
-      z: 0.0
+      x: 0.0       # model.x
+      y: 0.0       # -model.z
+      z: -0.02     # model.y
     upper_arm_cog:
-      x: 0.13
-      y: 0.0
-      z: 0.1157
+      x: -0.11365  # model.x - upper_arm_length
+      y: 0.0       # model.y
+      z: 0.1157    # model.z
     forearm_cog:
-      x: 0.05
-      y: 0.0
-      z: 0.0238
+      x: -0.16325  # model.x - forearm_length
+      y: 0.0       # model.y
+      z: 0.0238    # model.z
     wrist_1_cog:
-      x: 0.0
-      y: 0.0
-      z: 0.01
+      x: 0.0       # model.x
+      y: -0.01     # -model.z
+      z: 0.0       # model.y
     wrist_2_cog:
-      x: 0.0
-      y: 0.0
-      z: 0.01
+      x: 0.0       # model.x
+      y: 0.0       # model.z
+      z: 0.0       # -model.y
     wrist_3_cog:
-      x: 0.0
-      y: 0.0
-      z: -0.02
+      x: 0.0       # model.x
+      y: 0.0       # model.y
+      z: -0.02     # model.z
+
+  rotation:
+    shoulder:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    upper_arm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    forearm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    wrist_1:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_2:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_3:
+      roll: 0
+      pitch: 0
+      yaw: 0
+
+  # generated using cylinder approximation
+  tensor:
+    shoulder:
+      ixx: 0.008093166666666665
+      ixy: 0
+      ixz: 0
+      iyy: 0.008093166666666665
+      iyz: 0
+      izz: 0.005625
+    upper_arm:
+      ixx: 0.021728491912499998
+      ixy: 0
+      ixz: 0
+      iyy: 0.021728491912499998
+      iyz: 0
+      izz: 0.00961875
+    forearm:
+      ixx: 0.0065468090625
+      ixy: 0
+      ixz: 0
+      iyy: 0.0065468090625
+      iyz: 0
+      izz: 0.00354375
+    wrist_1:
+      ixx: 0.0016106414999999998
+      ixy: 0
+      ixz: 0
+      iyy: 0.0016106414999999998
+      iyz: 0
+      izz: 0.00225
+    wrist_2:
+      ixx: 0.0015721739999999998
+      ixy: 0
+      ixz: 0
+      iyy: 0.0015721739999999998
+      iyz: 0
+      izz: 0.00225
+    wrist_3:
+      ixx: 0.00013626666666666665
+      ixy: 0
+      ixz: 0
+      iyy: 0.00013626666666666665
+      iyz: 0
+      izz: 0.0001792

--- a/ur_description/config/ur3e/physical_parameters.yaml
+++ b/ur_description/config/ur3e/physical_parameters.yaml
@@ -4,7 +4,7 @@ dh_parameters:
   d1: 0.152
   a2: -0.244
   a3: -0.213
-  d4: 0.131  # wrist1_length = d4 - elbow_offset - shoulder_offset 
+  d4: 0.131  # wrist1_length = d4 - elbow_offset - shoulder_offset
   d5: 0.085
   d6: 0.092
 
@@ -53,26 +53,97 @@ inertia_parameters:
 
   center_of_mass:
     shoulder_cog:
-      x: 0.0
-      y: -0.02
-      z: 0.0
+      x: 0.0        # model.x
+      y: 0.0        # -model.z
+      z: -0.02      # model.y
     upper_arm_cog:
-      x: 0.13
-      y: 0.0
-      z: 0.1157
+      x: -0.11355   # model.x - upper_arm_length
+      y: 0.0        # model.y
+      z: 0.1157     # model.z
     forearm_cog:
-      x: 0.05
-      y: 0.0
-      z: 0.0238
+      x: -0.1632    # model.x - forearm_length
+      y: 0.0        # model.y
+      z: 0.0238     # model.z
     wrist_1_cog:
-      x: 0.0
-      y: 0.0
-      z: 0.01
+      x: 0.0        # model.x
+      y: -0.01      # -model.z
+      z: 0.0        # model.y
     wrist_2_cog:
-      x: 0.0
-      y: 0.0
-      z: 0.01
+      x: 0.0        # model.x
+      y: 0.01       # model.z
+      z: 0.0        # -model.y
     wrist_3_cog:
-      x: 0.0
-      y: 0.0
-      z: -0.02
+      x: 0.0        # model.x
+      y: 0.0        # model.y
+      z: -0.02      # model.z
+
+  rotation:
+    shoulder:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    upper_arm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    forearm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    wrist_1:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_2:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_3:
+      roll: 0
+      pitch: 0
+      yaw: 0
+
+  # generated using cylinder approximation
+  tensor:
+    shoulder:
+      ixx: 0.008093166666666665
+      ixy: 0
+      ixz: 0
+      iyy: 0.008093166666666665
+      iyz: 0
+      izz: 0.005625
+    upper_arm:
+      ixx: 0.021728491912499998
+      ixy: 0
+      ixz: 0
+      iyy: 0.021728491912499998
+      iyz: 0
+      izz: 0.00961875
+    forearm:
+      ixx: 0.006544570199999999
+      ixy: 0
+      ixz: 0
+      iyy: 0.006544570199999999
+      iyz: 0
+      izz: 0.00354375
+    wrist_1:
+      ixx: 0.0020849999999999996
+      ixy: 0
+      ixz: 0
+      iyy: 0.0020849999999999996
+      iyz: 0
+      izz: 0.00225
+    wrist_2:
+      ixx: 0.0020849999999999996
+      ixy: 0
+      ixz: 0
+      iyy: 0.0020849999999999996
+      iyz: 0
+      izz: 0.00225
+    wrist_3:
+      ixx: 0.00013626666666666665
+      ixy: 0
+      ixz: 0
+      iyy: 0.00013626666666666665
+      iyz: 0
+      izz: 0.0001792

--- a/ur_description/config/ur5/physical_parameters.yaml
+++ b/ur_description/config/ur5/physical_parameters.yaml
@@ -62,26 +62,97 @@ inertia_parameters:
 
   center_of_mass:
     shoulder_cog:
-      x: 0.0
-      y: 0.00193
-      z: -0.02561
+      x: 0.0       # model.x
+      y: -0.00193  # -model.z
+      z: -0.02561  # model.y
     upper_arm_cog:
-      x: 0.0
-      y: -0.024201
-      z: 0.2125
+      x: -0.2125   # model.x - upper_arm_length
+      y: 0.0       # model.y
+      z: 0.11336   # model.z
     forearm_cog:
-      x: 0.0
-      y: 0.0265
-      z: 0.11993
+      x: -0.24225  # model.x - forearm_length
+      y: 0.0       # model.y
+      z: 0.0265    # model.z
     wrist_1_cog:
-      x: 0.0
-      y: 0.110949
-      z: 0.01634
+      x: 0.0       # model.x
+      y: -0.01634  # -model.z
+      z: -0.0018   # model.y
     wrist_2_cog:
-      x: 0.0
-      y: 0.0018
-      z: 0.11099
+      x: 0.0       # model.x
+      y: 0.01634   # model.z
+      z: -0.0018   # -model.y
     wrist_3_cog:
-      x: 0.0
-      y: 0.001159
-      z: 0.0
+      x: 0.0       # model.x
+      y: 0.0       # model.y
+      z: -0.001159 # model.z
+
+  rotation:
+    shoulder:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    upper_arm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    forearm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    wrist_1:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_2:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_3:
+      roll: 0
+      pitch: 0
+      yaw: 0
+
+  # generated using cylinder approximation
+  tensor:
+    shoulder:
+      ixx: 0.014972358333333331
+      ixy: 0
+      ixz: 0
+      iyy: 0.014972358333333331
+      iyz: 0
+      izz: 0.01040625
+    upper_arm:
+      ixx: 0.13388583541666665
+      ixy: 0
+      ixz: 0
+      iyy: 0.13388583541666665
+      iyz: 0
+      izz: 0.0151074
+    forearm:
+      ixx: 0.031216803515624995
+      ixy: 0
+      ixz: 0
+      iyy: 0.031216803515624995
+      iyz: 0
+      izz: 0.004095
+    wrist_1:
+      ixx: 0.002013889583333333
+      ixy: 0
+      ixz: 0
+      iyy: 0.002013889583333333
+      iyz: 0
+      izz: 0.0021942
+    wrist_2:
+      ixx: 0.0018310395833333333
+      ixy: 0
+      ixz: 0
+      iyy: 0.0018310395833333333
+      iyz: 0
+      izz: 0.0021942
+    wrist_3:
+      ixx: 8.062475833333332e-05
+      ixy: 0
+      ixz: 0
+      iyy: 8.062475833333332e-05
+      iyz: 0
+      izz: 0.0001321171875

--- a/ur_description/config/ur5e/physical_parameters.yaml
+++ b/ur_description/config/ur5e/physical_parameters.yaml
@@ -53,26 +53,97 @@ inertia_parameters:
 
   center_of_mass:
     shoulder_cog:
-      x: 0.0
-      y: 0.00193
-      z: -0.02561
+      x: 0.0        # model.x
+      y: -0.00193   # -model.z
+      z: -0.02561   # model.y
     upper_arm_cog:
-      x: 0.0
-      y: -0.024201
-      z: 0.2125
+      x: -0.17       # model.x - upper_arm_length
+      y: 0.0        # model.y
+      z: 0.11336    # model.z
     forearm_cog:
-      x: 0.0
-      y: 0.0265
-      z: 0.11993
+      x: -0.2422    # model.x - forearm_length
+      y: 0.0        # model.y
+      z: 0.0265     # model.z
     wrist_1_cog:
-      x: 0.0
-      y: 0.110949
-      z: 0.01634
+      x: 0.0        # model.x
+      y: -0.01634   # -model.z
+      z: -0.0018    # model.y
     wrist_2_cog:
-      x: 0.0
-      y: 0.0018
-      z: 0.11099
+      x: 0.0        # model.x
+      y: 0.01634    # model.z
+      z: -0.0018    # -model.y
     wrist_3_cog:
-      x: 0.0
-      y: 0.001159
-      z: 0.0
+      x: 0.0        # model.x
+      y: 0.0        # model.y
+      z: -0.001159  # model.z
+
+  rotation:
+    shoulder:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    upper_arm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    forearm:
+      roll: 0
+      pitch: 1.570796326794897
+      yaw: 0
+    wrist_1:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_2:
+      roll: 0
+      pitch: 0
+      yaw: 0
+    wrist_3:
+      roll: 0
+      pitch: 0
+      yaw: 0
+
+  # generated using cylinder approximation
+  tensor:
+    shoulder:
+      ixx: 0.010267499999999999
+      ixy: 0
+      ixz: 0
+      iyy: 0.010267499999999999
+      iyz: 0
+      izz: 0.00666
+    upper_arm:
+      ixx: 0.13388583541666665
+      ixy: 0
+      ixz: 0
+      iyy: 0.13388583541666665
+      iyz: 0
+      izz: 0.0151074
+    forearm:
+      ixx: 0.03120936758333333
+      ixy: 0
+      ixz: 0
+      iyy: 0.03120936758333333
+      iyz: 0
+      izz: 0.004095
+    wrist_1:
+      ixx: 0.0025599
+      ixy: 0
+      ixz: 0
+      iyy: 0.0025599
+      iyz: 0
+      izz: 0.0021942
+    wrist_2:
+      ixx: 0.0025599
+      ixy: 0
+      ixz: 0
+      iyy: 0.0025599
+      iyz: 0
+      izz: 0.0021942
+    wrist_3:
+      ixx: 9.890414008333333e-05
+      ixy: 0
+      ixz: 0
+      iyy: 9.890414008333333e-05
+      iyz: 0
+      izz: 0.0001321171875

--- a/ur_description/urdf/inc/ur_common.xacro
+++ b/ur_description/urdf/inc/ur_common.xacro
@@ -164,6 +164,68 @@
     <xacro:property name="wrist_1_cog" value="${__wrist_1_cog['x']} ${__wrist_1_cog['y']} ${__wrist_1_cog['z']}" scope="parent"/>
     <xacro:property name="wrist_2_cog" value="${__wrist_2_cog['x']} ${__wrist_2_cog['y']} ${__wrist_2_cog['z']}" scope="parent"/>
     <xacro:property name="wrist_3_cog" value="${__wrist_3_cog['x']} ${__wrist_3_cog['y']} ${__wrist_3_cog['z']}" scope="parent"/>
+
+    <!-- inertia rotation -->
+    <xacro:property name="__shoulder_inertia_rotation" value="${__inertia_parameters['rotation']['shoulder']}" scope="parent"/>
+    <xacro:property name="__upper_arm_inertia_rotation" value="${__inertia_parameters['rotation']['upper_arm']}" scope="parent"/>
+    <xacro:property name="__forearm_inertia_rotation" value="${__inertia_parameters['rotation']['forearm']}" scope="parent"/>
+    <xacro:property name="__wrist_1_inertia_rotation" value="${__inertia_parameters['rotation']['wrist_1']}" scope="parent"/>
+    <xacro:property name="__wrist_2_inertia_rotation" value="${__inertia_parameters['rotation']['wrist_2']}" scope="parent"/>
+    <xacro:property name="__wrist_3_inertia_rotation" value="${__inertia_parameters['rotation']['wrist_3']}" scope="parent"/>
+
+    <xacro:property name="shoulder_inertia_rotation" value="${__shoulder_inertia_rotation['roll']} ${__shoulder_inertia_rotation['pitch']} ${__shoulder_inertia_rotation['yaw']}" scope="parent"/>
+    <xacro:property name="upper_arm_inertia_rotation" value="${__upper_arm_inertia_rotation['roll']} ${__upper_arm_inertia_rotation['pitch']} ${__upper_arm_inertia_rotation['yaw']}" scope="parent"/>
+    <xacro:property name="forearm_inertia_rotation" value="${__forearm_inertia_rotation['roll']} ${__forearm_inertia_rotation['pitch']} ${__forearm_inertia_rotation['yaw']}" scope="parent"/>
+    <xacro:property name="wrist_1_inertia_rotation" value="${__wrist_1_inertia_rotation['roll']} ${__wrist_1_inertia_rotation['pitch']} ${__wrist_1_inertia_rotation['yaw']}" scope="parent"/>
+    <xacro:property name="wrist_2_inertia_rotation" value="${__wrist_2_inertia_rotation['roll']} ${__wrist_2_inertia_rotation['pitch']} ${__wrist_2_inertia_rotation['yaw']}" scope="parent"/>
+    <xacro:property name="wrist_3_inertia_rotation" value="${__wrist_3_inertia_rotation['roll']} ${__wrist_3_inertia_rotation['pitch']} ${__wrist_3_inertia_rotation['yaw']}" scope="parent"/>
+
+
+    <!-- tensors -->
+    <xacro:property name="__shoulder_inertia" value="${__inertia_parameters['tensor']['shoulder']}" scope="parent"/>
+    <xacro:property name="__upper_arm_inertia" value="${__inertia_parameters['tensor']['upper_arm']}" scope="parent"/>
+    <xacro:property name="__forearm_inertia" value="${__inertia_parameters['tensor']['forearm']}" scope="parent"/>
+    <xacro:property name="__wrist_1_inertia" value="${__inertia_parameters['tensor']['wrist_1']}" scope="parent"/>
+    <xacro:property name="__wrist_2_inertia" value="${__inertia_parameters['tensor']['wrist_2']}" scope="parent"/>
+    <xacro:property name="__wrist_3_inertia" value="${__inertia_parameters['tensor']['wrist_3']}" scope="parent"/>
+
+    <xacro:property name="shoulder_inertia_ixx" value="${__shoulder_inertia['ixx']}" scope="parent"/>
+    <xacro:property name="shoulder_inertia_ixy" value="${__shoulder_inertia['ixy']}" scope="parent"/>
+    <xacro:property name="shoulder_inertia_ixz" value="${__shoulder_inertia['ixz']}" scope="parent"/>
+    <xacro:property name="shoulder_inertia_iyy" value="${__shoulder_inertia['iyy']}" scope="parent"/>
+    <xacro:property name="shoulder_inertia_iyz" value="${__shoulder_inertia['iyz']}" scope="parent"/>
+    <xacro:property name="shoulder_inertia_izz" value="${__shoulder_inertia['izz']}" scope="parent"/>
+    <xacro:property name="upper_arm_inertia_ixx" value="${__upper_arm_inertia['ixx']}" scope="parent"/>
+    <xacro:property name="upper_arm_inertia_ixy" value="${__upper_arm_inertia['ixy']}" scope="parent"/>
+    <xacro:property name="upper_arm_inertia_ixz" value="${__upper_arm_inertia['ixz']}" scope="parent"/>
+    <xacro:property name="upper_arm_inertia_iyy" value="${__upper_arm_inertia['iyy']}" scope="parent"/>
+    <xacro:property name="upper_arm_inertia_iyz" value="${__upper_arm_inertia['iyz']}" scope="parent"/>
+    <xacro:property name="upper_arm_inertia_izz" value="${__upper_arm_inertia['izz']}" scope="parent"/>
+    <xacro:property name="forearm_inertia_ixx" value="${__forearm_inertia['ixx']}" scope="parent"/>
+    <xacro:property name="forearm_inertia_ixy" value="${__forearm_inertia['ixy']}" scope="parent"/>
+    <xacro:property name="forearm_inertia_ixz" value="${__forearm_inertia['ixz']}" scope="parent"/>
+    <xacro:property name="forearm_inertia_iyy" value="${__forearm_inertia['iyy']}" scope="parent"/>
+    <xacro:property name="forearm_inertia_iyz" value="${__forearm_inertia['iyz']}" scope="parent"/>
+    <xacro:property name="forearm_inertia_izz" value="${__forearm_inertia['izz']}" scope="parent"/>
+    <xacro:property name="wrist_1_inertia_ixx" value="${__wrist_1_inertia['ixx']}" scope="parent"/>
+    <xacro:property name="wrist_1_inertia_ixy" value="${__wrist_1_inertia['ixy']}" scope="parent"/>
+    <xacro:property name="wrist_1_inertia_ixz" value="${__wrist_1_inertia['ixz']}" scope="parent"/>
+    <xacro:property name="wrist_1_inertia_iyy" value="${__wrist_1_inertia['iyy']}" scope="parent"/>
+    <xacro:property name="wrist_1_inertia_iyz" value="${__wrist_1_inertia['iyz']}" scope="parent"/>
+    <xacro:property name="wrist_1_inertia_izz" value="${__wrist_1_inertia['izz']}" scope="parent"/>
+    <xacro:property name="wrist_2_inertia_ixx" value="${__wrist_2_inertia['ixx']}" scope="parent"/>
+    <xacro:property name="wrist_2_inertia_ixy" value="${__wrist_2_inertia['ixy']}" scope="parent"/>
+    <xacro:property name="wrist_2_inertia_ixz" value="${__wrist_2_inertia['ixz']}" scope="parent"/>
+    <xacro:property name="wrist_2_inertia_iyy" value="${__wrist_2_inertia['iyy']}" scope="parent"/>
+    <xacro:property name="wrist_2_inertia_iyz" value="${__wrist_2_inertia['iyz']}" scope="parent"/>
+    <xacro:property name="wrist_2_inertia_izz" value="${__wrist_2_inertia['izz']}" scope="parent"/>
+    <xacro:property name="wrist_3_inertia_ixx" value="${__wrist_3_inertia['ixx']}" scope="parent"/>
+    <xacro:property name="wrist_3_inertia_ixy" value="${__wrist_3_inertia['ixy']}" scope="parent"/>
+    <xacro:property name="wrist_3_inertia_ixz" value="${__wrist_3_inertia['ixz']}" scope="parent"/>
+    <xacro:property name="wrist_3_inertia_iyy" value="${__wrist_3_inertia['iyy']}" scope="parent"/>
+    <xacro:property name="wrist_3_inertia_iyz" value="${__wrist_3_inertia['iyz']}" scope="parent"/>
+    <xacro:property name="wrist_3_inertia_izz" value="${__wrist_3_inertia['izz']}" scope="parent"/>
+
     <!-- cylinder radius -->
     <xacro:property name="shoulder_radius" value="${__inertia_parameters['shoulder_radius']}" scope="parent"/>
     <xacro:property name="upper_arm_radius" value="${__inertia_parameters['upper_arm_radius']}" scope="parent"/>

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -113,9 +113,18 @@
           <mesh filename="${shoulder_collision_mesh}"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="${shoulder_inertia_radius}" length="${shoulder_inertia_length}" mass="${shoulder_mass}">
-        <origin xyz="${shoulder_cog}" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
+      <inertial>
+        <mass value="${shoulder_mass}"/>
+        <origin rpy="${shoulder_inertia_rotation}" xyz="${shoulder_cog}"/>
+        <inertia
+            ixx="${shoulder_inertia_ixx}"
+            ixy="${shoulder_inertia_ixy}"
+            ixz="${shoulder_inertia_ixz}"
+            iyy="${shoulder_inertia_iyy}"
+            iyz="${shoulder_inertia_iyz}"
+            izz="${shoulder_inertia_izz}"
+        />
+      </inertial>
     </link>
     <link name="${prefix}upper_arm_link">
       <visual>
@@ -133,9 +142,18 @@
           <mesh filename="${upper_arm_collision_mesh}"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="${upperarm_inertia_radius}" length="${upperarm_inertia_length}" mass="${upper_arm_mass}">
-        <origin xyz="${upper_arm_cog}" rpy="0 ${pi/2} 0" />
-      </xacro:cylinder_inertial>
+      <inertial>
+        <mass value="${upper_arm_mass}"/>
+        <origin rpy="${upper_arm_inertia_rotation}" xyz="${upper_arm_cog}"/>
+        <inertia
+            ixx="${upper_arm_inertia_ixx}"
+            ixy="${upper_arm_inertia_ixy}"
+            ixz="${upper_arm_inertia_ixz}"
+            iyy="${upper_arm_inertia_iyy}"
+            iyz="${upper_arm_inertia_iyz}"
+            izz="${upper_arm_inertia_izz}"
+        />
+      </inertial>
     </link>
     <link name="${prefix}forearm_link">
       <visual>
@@ -153,9 +171,18 @@
           <mesh filename="${forearm_collision_mesh}"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="${forearm_inertia_radius}" length="${forearm_inertia_length}"  mass="${forearm_mass}">
-        <origin xyz="${forearm_cog}" rpy="0 ${pi/2} 0" />
-      </xacro:cylinder_inertial>
+      <inertial>
+        <mass value="${forearm_mass}"/>
+        <origin rpy="${forearm_inertia_rotation}" xyz="${forearm_cog}"/>
+        <inertia
+            ixx="${forearm_inertia_ixx}"
+            ixy="${forearm_inertia_ixy}"
+            ixz="${forearm_inertia_ixz}"
+            iyy="${forearm_inertia_iyy}"
+            iyz="${forearm_inertia_iyz}"
+            izz="${forearm_inertia_izz}"
+        />
+      </inertial>
     </link>
     <link name="${prefix}wrist_1_link">
       <visual>
@@ -174,9 +201,18 @@
           <mesh filename="${wrist_1_collision_mesh}"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="${wrist_1_inertia_radius}" length="${wrist_1_inertia_length}"  mass="${wrist_1_mass}">
-        <origin xyz="${wrist_1_cog}" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
+      <inertial>
+        <mass value="${wrist_1_mass}"/>
+        <origin rpy="${wrist_1_inertia_rotation}" xyz="${wrist_1_cog}"/>
+        <inertia
+            ixx="${wrist_1_inertia_ixx}"
+            ixy="${wrist_1_inertia_ixy}"
+            ixz="${wrist_1_inertia_ixz}"
+            iyy="${wrist_1_inertia_iyy}"
+            iyz="${wrist_1_inertia_iyz}"
+            izz="${wrist_1_inertia_izz}"
+        />
+      </inertial>
     </link>
     <link name="${prefix}wrist_2_link">
       <visual>
@@ -194,9 +230,18 @@
           <mesh filename="${wrist_2_collision_mesh}"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="${wrist_2_inertia_radius}" length="${wrist_2_inertia_length}"  mass="${wrist_2_mass}">
-        <origin xyz="${wrist_2_cog}" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
+      <inertial>
+        <mass value="${wrist_2_mass}"/>
+        <origin rpy="${wrist_2_inertia_rotation}" xyz="${wrist_2_cog}"/>
+        <inertia
+            ixx="${wrist_2_inertia_ixx}"
+            ixy="${wrist_2_inertia_ixy}"
+            ixz="${wrist_2_inertia_ixz}"
+            iyy="${wrist_2_inertia_iyy}"
+            iyz="${wrist_2_inertia_iyz}"
+            izz="${wrist_2_inertia_izz}"
+        />
+      </inertial>
     </link>
     <link name="${prefix}wrist_3_link">
       <visual>
@@ -214,9 +259,18 @@
           <mesh filename="${wrist_3_collision_mesh}"/>
         </geometry>
       </collision>
-      <xacro:cylinder_inertial radius="${wrist_3_inertia_radius}" length="${wrist_3_inertia_length}"  mass="${wrist_3_mass}">
-        <origin xyz="${wrist_3_cog}" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
+      <inertial>
+        <mass value="${wrist_3_mass}"/>
+        <origin rpy="${wrist_3_inertia_rotation}" xyz="${wrist_3_cog}"/>
+        <inertia
+            ixx="${wrist_3_inertia_ixx}"
+            ixy="${wrist_3_inertia_ixy}"
+            ixz="${wrist_3_inertia_ixz}"
+            iyy="${wrist_3_inertia_iyy}"
+            iyz="${wrist_3_inertia_iyz}"
+            izz="${wrist_3_inertia_izz}"
+        />
+      </inertial>
     </link>
 
     <!-- joints: main serial chain -->

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -114,7 +114,7 @@
         </geometry>
       </collision>
       <xacro:cylinder_inertial radius="${shoulder_inertia_radius}" length="${shoulder_inertia_length}" mass="${shoulder_mass}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin xyz="${shoulder_cog}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
     <link name="${prefix}upper_arm_link">
@@ -134,7 +134,7 @@
         </geometry>
       </collision>
       <xacro:cylinder_inertial radius="${upperarm_inertia_radius}" length="${upperarm_inertia_length}" mass="${upper_arm_mass}">
-        <origin xyz="${-0.5 * upperarm_inertia_length} 0.0 ${upper_arm_inertia_offset}" rpy="0 ${pi/2} 0" />
+        <origin xyz="${upper_arm_cog}" rpy="0 ${pi/2} 0" />
       </xacro:cylinder_inertial>
     </link>
     <link name="${prefix}forearm_link">
@@ -154,7 +154,7 @@
         </geometry>
       </collision>
       <xacro:cylinder_inertial radius="${forearm_inertia_radius}" length="${forearm_inertia_length}"  mass="${forearm_mass}">
-        <origin xyz="${-0.5 * forearm_inertia_length} 0.0 ${elbow_offset}" rpy="0 ${pi/2} 0" />
+        <origin xyz="${forearm_cog}" rpy="0 ${pi/2} 0" />
       </xacro:cylinder_inertial>
     </link>
     <link name="${prefix}wrist_1_link">
@@ -175,7 +175,7 @@
         </geometry>
       </collision>
       <xacro:cylinder_inertial radius="${wrist_1_inertia_radius}" length="${wrist_1_inertia_length}"  mass="${wrist_1_mass}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin xyz="${wrist_1_cog}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
     <link name="${prefix}wrist_2_link">
@@ -195,7 +195,7 @@
         </geometry>
       </collision>
       <xacro:cylinder_inertial radius="${wrist_2_inertia_radius}" length="${wrist_2_inertia_length}"  mass="${wrist_2_mass}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin xyz="${wrist_2_cog}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
     <link name="${prefix}wrist_3_link">
@@ -215,7 +215,7 @@
         </geometry>
       </collision>
       <xacro:cylinder_inertial radius="${wrist_3_inertia_radius}" length="${wrist_3_inertia_length}"  mass="${wrist_3_mass}">
-        <origin xyz="0.0 0.0 ${-0.5 * wrist_3_inertia_length}" rpy="0 0 0" />
+        <origin xyz="${wrist_3_cog}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
 


### PR DESCRIPTION
This PR spins out of #460, as it not only affects the UR16e.

Up until now, the robots' CoG calculation were centered inside the links they were referring to. This PR sets them to the place where they are supposed to be according to [UR's documentation](https://www.universal-robots.com/how-tos-and-faqs/faq/ur-faq/parameters-for-calculations-of-kinematics-and-dynamics-45257/)

The actual inertia matrix isn't changed by this PR, that might still have to be updated. UR provides 3x3 inertia matrices, but (at least in URSim) the ones from the ur3e and ur5e seem to be very sparse (the following files are from a URSim v5.8, so all robots are actually e-Series):
```
urcontrol.conf.UR3:inertia_matrix = [ [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0.000144] ]
urcontrol.conf.UR16:inertia_matrix = [ [0.03351, 0.00002, -0.00001, 0.00002, 0.03374, 0.00374, -0.00001, 0.00374, 0.02100], [0.02796, -0.00010, -0.00720, -0.00010, 0.47558, 0.00003, -0.00720, -0.00001, 0.47635], [0.01091, 0.00006, 0.01012, 0.00006, 0.12060, 0.00001, 0.01012, 0.00001, 0.11714], [0.00609, -0.00001, -0.00000, -0.00001, 0.00245, 0.00083, 0.00000, 0.00083, 0.00579], [0.00389, -0.00001, 0.00000, -0.00001, 0.00219, -0.00045, 0.00000, -0.00045, 0.00363], [0.00117, 0.00000,  0.00000, 0.00000, 0.00118, 0.00000, 0.00000, 0.00000, 0.00084] ]
urcontrol.conf.UR10:inertia_matrix = [ [0.03408, 0.00002, -0.00425, 0.00002, 0.03529, 0.00008, 0.00425, 0.00008, 0.02156], [0.02814, 0.00005, -0.01561, 0.00005, 0.77068, 0.00002, -0.01561, 0.00002, 0.76943], [0.01014, 0.00008, 0.00916, 0.00008, 0.30928, 0.00000, 0.00916, 0.00000, 0.30646], [0.00296, -0.00001, -0.00000, -0.00001, 0.00222, -0.00024, -0.00000, -0.00024, 0.00258], [0.00296, -0.00001, -0.00000, -0.00001, 0.00222, -0.00024, -0.00000, -0.00024, 0.00258], [0.00040, 0.00000,  -0.00000, 0.00000, 0.00041, 0.00000, -0.00000, 0.00000, 0.00034] ]
urcontrol.conf.UR5:inertia_matrix = [ [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0.0002] ]
```

Currently, this is a draft implementation for the UR16e. If somebody with more experience about inertias than me could have a look at this, I'd be happy do adapt the parameters for the other robots, as well.

ToDo:
 - [ ] verify that I am actually doing the right thing -> help needed
 - [ ] Update inertia cylinder dimensions -> How should we handle those?
 - [x] Update ur3
 - [x] Update ur5
 - [x] Update ur10
 - [x] Update ur3e
 - [x] Update ur5e
 - [x] Update ur10e
