### PR TITLE
Add flange frame

### DIFF
--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -320,7 +320,8 @@
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <!-- default toolframe: X+ left, Y+ up, Z+ front -->
+      <origin xyz="0 0 0" rpy="${pi/2.0} 0 ${pi/2.0}"/>
       <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -297,7 +297,7 @@
       <dynamics damping="0" friction="0"/>
     </joint>
 
-    <!-- ROS base_link to UR 'Base' Coordinates transform -->
+    <!-- ROS-Industrial 'base' frame: base_link to UR 'Base' Coordinates transform -->
     <link name="${prefix}base"/>
     <joint name="${prefix}base_link-base_fixed_joint" type="fixed">
       <!-- NOTE: this rotation is only needed as long as base_link itself is
@@ -317,7 +317,7 @@
       <origin xyz="0 0 0" rpy="0 ${-pi/2.0} ${-pi/2.0}" />
     </joint>
 
-    <!-- Frame coincident with all-zeros TCP on UR controller -->
+    <!-- ROS-Industrial 'tool0' frame: all-zeros tool frame -->
     <link name="${prefix}tool0"/>
     <joint name="${prefix}flange-tool0" type="fixed">
       <!-- default toolframe: X+ left, Y+ up, Z+ front -->

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -225,19 +225,6 @@
         <origin xyz="0.0 0.0 ${-0.5 * wrist_3_inertia_length}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
-    <link name="${prefix}ee_link">
-      <!-- TODO: remove this. This was only added to work-around a MoveIt issue
-           where links without geometry were ignored while collision checking.
-
-           NOTE: this will be removed in a future revision of this file.
-      -->
-      <collision>
-        <geometry>
-          <box size="0.01 0.01 0.01"/>
-        </geometry>
-        <origin rpy="0 0 0" xyz="-0.01 0 0"/>
-      </collision>
-    </link>
 
     <!-- joints: main serial chain -->
     <joint name="${prefix}shoulder_pan_joint" type="revolute">
@@ -308,11 +295,6 @@
          <safety_controller soft_lower_limit="${wrist_3_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_3_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
       </xacro:if>
       <dynamics damping="0" friction="0"/>
-    </joint>
-    <joint name="${prefix}ee_fixed_joint" type="fixed">
-      <parent link="${prefix}wrist_3_link" />
-      <child link="${prefix}ee_link" />
-      <origin xyz="0 0 0" rpy="0.0 ${-pi/2.0} ${pi/2.0}" />
     </joint>
 
     <!-- ROS base_link to UR 'Base' Coordinates transform -->

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -309,11 +309,19 @@
       <child link="${prefix}base"/>
     </joint>
 
+    <!-- ROS-Industrial 'flange' frame: attachment point for EEF models -->
+    <link name="${prefix}flange" />
+    <joint name="${prefix}wrist_3-flange" type="fixed">
+      <parent link="${prefix}wrist_3_link" />
+      <child link="${prefix}flange" />
+      <origin xyz="0 0 0" rpy="0 ${-pi/2.0} ${-pi/2.0}" />
+    </joint>
+
     <!-- Frame coincident with all-zeros TCP on UR controller -->
     <link name="${prefix}tool0"/>
-    <joint name="${prefix}wrist_3_passive_joint" type="fixed">
+    <joint name="${prefix}flange-tool0" type="fixed">
       <origin xyz="0 0 0" rpy="0 0 0"/>
-      <parent link="${prefix}wrist_3_link"/>
+      <parent link="${prefix}flange"/>
       <child link="${prefix}tool0"/>
     </joint>
   </xacro:macro>


### PR DESCRIPTION
As per subject.

This makes `ur_description` adhere to the (WIP) REP [Coordinate Frames for Serial Industrial Manipulators](http://gavanderhoorn.github.io/rep/rep-0199.html) and aligns it with other ROS-Industrial robot support packages (such as those for ABB and Fanuc).

Users will have to use `flange` as the EEF attachment point, instead of `ee_link`. `tool0` will always be coincident with an unconfigured (or "all zeros") toolframe, and must not be changed.

This is for #448.
