### PR TITLE
description: use mat def from yaml for base_link.

### DIFF
--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -90,8 +90,8 @@
         <geometry>
           <mesh filename="${base_visual_mesh}"/>
         </geometry>
-        <material name="LightGrey">
-          <color rgba="0.7 0.7 0.7 1.0"/>
+        <material name="${base_visual_material_name}">
+          <color rgba="${base_visual_material_color}"/>
         </material>
       </visual>
       <collision>


### PR DESCRIPTION
As per subject.

For some reason, `base_link` was still using the in-urdf defined `material` and `color` defs.

Probably an oversight in #371.
