### PR TITLE
Switch UR10, UR10e and UR16e to effort controllers

### DIFF
--- a/ur_gazebo/config/ur10_controllers.yaml
+++ b/ur_gazebo/config/ur10_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 125
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur10e_controllers.yaml
+++ b/ur_gazebo/config/ur10e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur16e_controllers.yaml
+++ b/ur_gazebo/config/ur16e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur3_controllers.yaml
+++ b/ur_gazebo/config/ur3_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 125
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur3e_controllers.yaml
+++ b/ur_gazebo/config/ur3e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur5_controllers.yaml
+++ b/ur_gazebo/config/ur5_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 125
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur5e_controllers.yaml
+++ b/ur_gazebo/config/ur5e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/launch/inc/load_ur.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur.launch.xml
@@ -25,7 +25,7 @@
   <arg name="visual_params" doc="YAML file containing the visual model of the robots"/>
 
   <!--Common parameters  -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur10.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur10.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur10/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur10e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur10e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur10e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur16e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur16e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur16e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur3.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur3.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur3/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur3e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur3e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur3e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur5.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur5/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur5e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur5e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/ur_control.launch.xml
+++ b/ur_gazebo/launch/inc/ur_control.launch.xml
@@ -17,8 +17,8 @@
 
   <!-- Parameters we share with ur_robot_driver -->
   <arg name="controller_config_file" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller"/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller"/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller"/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller"/>
 
   <!-- Gazebo parameters -->
   <arg name="gazebo_model_name" default="robot" doc="The name to give to the model in Gazebo (after spawning it)." />

--- a/ur_gazebo/launch/ur10_bringup.launch
+++ b/ur_gazebo/launch/ur10_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur10_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur10e_bringup.launch
+++ b/ur_gazebo/launch/ur10e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur10e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur16e_bringup.launch
+++ b/ur_gazebo/launch/ur16e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur16e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur3_bringup.launch
+++ b/ur_gazebo/launch/ur3_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur3_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur3e_bringup.launch
+++ b/ur_gazebo/launch/ur3e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur3e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur5_bringup.launch
+++ b/ur_gazebo/launch/ur5_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur5_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur5e_bringup.launch
+++ b/ur_gazebo/launch/ur5e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur5e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/urdf/ur.xacro
+++ b/ur_gazebo/urdf/ur.xacro
@@ -45,7 +45,7 @@
     NOTE: this value must correspond to the controller configured in the
           controller .yaml files in the 'config' directory.
   -->
-  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface"/>
   <xacro:arg name="safety_limits" default="false"/>
   <xacro:arg name="safety_pos_margin" default="0.15"/>
   <xacro:arg name="safety_k_position" default="20"/>

--- a/ur_gazebo/urdf/ur_macro.xacro
+++ b/ur_gazebo/urdf/ur_macro.xacro
@@ -46,7 +46,7 @@
    kinematics_parameters_file
    physical_parameters_file
    visual_parameters_file
-   transmission_hw_interface:=hardware_interface/PositionJointInterface
+   transmission_hw_interface:=hardware_interface/EffortJointInterface
    safety_limits:=false safety_pos_margin:=0.15 safety_k_position:=20"
   >
     <!--


### PR DESCRIPTION
This fix addresses https://github.com/ros-industrial/universal_robot/issues/521 which in turn addresses https://github.com/ros-industrial/universal_robot/issues/386, and was worked on during WRID2020

Based on a rough understanding of [this comment](https://github.com/ros-industrial/universal_robot/pull/504#issuecomment-652394378), only the three URs mentioned in the title have been updated.

PID values for the effort controllers were taken from [here](https://github.com/fmauch/universal_robot/commit/0d2ec11e2ac4a55317ffe427e16c1a949a1a4bee) 

After making these changes, the gazebo simulation of the robot was observed to start in a "weird" pose :
UR16e:   
![initial_pose_16e](https://user-images.githubusercontent.com/54175171/86779047-635fc880-c05b-11ea-9678-5582fda64d30.png)

UR10 and UR10e:   
![initial_pos_10e](https://user-images.githubusercontent.com/54175171/86779110-7377a800-c05b-11ea-90d8-dc3d08006a04.png)

However, the controllers initially seem to initially work well, and the robots could be jogged using the [RQT Joint trajectory controller plugin](http://wiki.ros.org/rqt_joint_trajectory_controller)
