### PR TITLE
Improve Gazebo PID parameters for all robots

### DIFF
--- a/ur_gazebo/config/ur10_controllers.yaml
+++ b/ur_gazebo/config/ur10_controllers.yaml
@@ -12,12 +12,12 @@ eff_joint_traj_controller:
     - wrist_2_joint
     - wrist_3_joint
   gains: # Required because we're controlling an effort interface
-    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
-    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
-    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_pan_joint: {p: 20000,  d: 100, i: 10, i_clamp: 1}
+    shoulder_lift_joint: {p: 20000,  d: 100, i: 20, i_clamp: 1}
+    elbow_joint: {p: 10000,  d: 100, i: 10, i_clamp: 1}
     wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
     wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
+    wrist_3_joint: {p: 10,  d: 0.1, i: 0, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05

--- a/ur_gazebo/config/ur10_controllers.yaml
+++ b/ur_gazebo/config/ur10_controllers.yaml
@@ -12,11 +12,11 @@ eff_joint_traj_controller:
     - wrist_2_joint
     - wrist_3_joint
   gains: # Required because we're controlling an effort interface
-    shoulder_pan_joint: {p: 20000,  d: 100, i: 10, i_clamp: 1}
-    shoulder_lift_joint: {p: 20000,  d: 100, i: 20, i_clamp: 1}
-    elbow_joint: {p: 10000,  d: 100, i: 10, i_clamp: 1}
-    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    shoulder_pan_joint: {p: 20000,  d: 500, i: 10, i_clamp: 1}
+    shoulder_lift_joint: {p: 20000,  d: 500, i: 10, i_clamp: 1}
+    elbow_joint: {p: 20000,  d: 500, i: 10, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 10, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 10, i: 1, i_clamp: 1}
     wrist_3_joint: {p: 10,  d: 0.1, i: 0, i_clamp: 1}  
   constraints:
     goal_time: 0.6

--- a/ur_gazebo/config/ur10_controllers.yaml
+++ b/ur_gazebo/config/ur10_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 125
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur10e_controllers.yaml
+++ b/ur_gazebo/config/ur10e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur10e_controllers.yaml
+++ b/ur_gazebo/config/ur10e_controllers.yaml
@@ -12,12 +12,12 @@ eff_joint_traj_controller:
     - wrist_2_joint
     - wrist_3_joint
   gains: # Required because we're controlling an effort interface
-    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
-    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
-    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_pan_joint: {p: 20000,  d: 100, i: 10, i_clamp: 1}
+    shoulder_lift_joint: {p: 20000,  d: 100, i: 20, i_clamp: 1}
+    elbow_joint: {p: 10000,  d: 100, i: 10, i_clamp: 1}
     wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
     wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
+    wrist_3_joint: {p: 10,  d: 0.1, i: 0, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05

--- a/ur_gazebo/config/ur16e_controllers.yaml
+++ b/ur_gazebo/config/ur16e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur16e_controllers.yaml
+++ b/ur_gazebo/config/ur16e_controllers.yaml
@@ -12,12 +12,12 @@ eff_joint_traj_controller:
     - wrist_2_joint
     - wrist_3_joint
   gains: # Required because we're controlling an effort interface
-    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
-    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
-    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
-    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
+    shoulder_pan_joint: {p: 20000,  d: 500, i: 10, i_clamp: 1}
+    shoulder_lift_joint: {p: 20000,  d: 500, i: 10, i_clamp: 1}
+    elbow_joint: {p: 10000,  d: 200, i: 10, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 10, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 10, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 100,  d: 0.1, i: 0, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05

--- a/ur_gazebo/config/ur3_controllers.yaml
+++ b/ur_gazebo/config/ur3_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 125
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur3_controllers.yaml
+++ b/ur_gazebo/config/ur3_controllers.yaml
@@ -17,7 +17,7 @@ eff_joint_traj_controller:
     elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
     wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
     wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
+    wrist_3_joint: {p: 10,  d: 0.1, i: 0, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05

--- a/ur_gazebo/config/ur3e_controllers.yaml
+++ b/ur_gazebo/config/ur3e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur3e_controllers.yaml
+++ b/ur_gazebo/config/ur3e_controllers.yaml
@@ -17,7 +17,7 @@ eff_joint_traj_controller:
     elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
     wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
     wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}  
+    wrist_3_joint: {p: 10,  d: 0.1, i: 0, i_clamp: 1}  
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05

--- a/ur_gazebo/config/ur5_controllers.yaml
+++ b/ur_gazebo/config/ur5_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 125
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur5_controllers.yaml
+++ b/ur_gazebo/config/ur5_controllers.yaml
@@ -12,12 +12,12 @@ eff_joint_traj_controller:
     - wrist_2_joint
     - wrist_3_joint
   gains: # Required because we're controlling an effort interface
-    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
-    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    shoulder_pan_joint: {p: 4000,  d: 200, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 10000,  d: 200, i: 1, i_clamp: 1}
     elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
     wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
     wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
+    wrist_3_joint: {p: 10,  d: 0.1, i: 0, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05

--- a/ur_gazebo/config/ur5e_controllers.yaml
+++ b/ur_gazebo/config/ur5e_controllers.yaml
@@ -2,8 +2,8 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
 
-pos_joint_traj_controller:
-  type: position_controllers/JointTrajectoryController
+eff_joint_traj_controller:
+  type: effort_controllers/JointTrajectoryController
   joints: &robot_joints
     - shoulder_pan_joint
     - shoulder_lift_joint
@@ -11,6 +11,13 @@ pos_joint_traj_controller:
     - wrist_1_joint
     - wrist_2_joint
     - wrist_3_joint
+  gains: # Required because we're controlling an effort interface
+    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
+    wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
+    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05
@@ -24,6 +31,6 @@ pos_joint_traj_controller:
   state_publish_rate: *loop_hz
   action_monitor_rate: 10
 
-joint_group_pos_controller:
-  type: position_controllers/JointGroupPositionController
+joint_group_eff_controller:
+  type: effort_controllers/JointGroupEffortController
   joints: *robot_joints

--- a/ur_gazebo/config/ur5e_controllers.yaml
+++ b/ur_gazebo/config/ur5e_controllers.yaml
@@ -12,12 +12,12 @@ eff_joint_traj_controller:
     - wrist_2_joint
     - wrist_3_joint
   gains: # Required because we're controlling an effort interface
-    shoulder_pan_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
-    shoulder_lift_joint: {p: 6000,  d: 40, i: 1, i_clamp: 1}
+    shoulder_pan_joint: {p: 4000,  d: 200, i: 1, i_clamp: 1}
+    shoulder_lift_joint: {p: 10000,  d: 200, i: 1, i_clamp: 1}
     elbow_joint: {p: 2000,  d: 20, i: 1, i_clamp: 1}
     wrist_1_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
     wrist_2_joint: {p: 500,  d: 1, i: 1, i_clamp: 1}
-    wrist_3_joint: {p: 500,  d: 1, i: 1, i_clamp: 1} 
+    wrist_3_joint: {p: 10,  d: 0.1, i: 0, i_clamp: 1} 
   constraints:
     goal_time: 0.6
     stopped_velocity_tolerance: 0.05

--- a/ur_gazebo/launch/inc/load_ur.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur.launch.xml
@@ -25,7 +25,7 @@
   <arg name="visual_params" doc="YAML file containing the visual model of the robots"/>
 
   <!--Common parameters  -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur10.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur10.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur10/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur10e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur10e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur10e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur16e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur16e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur16e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur3.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur3.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur3/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur3e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur3e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur3e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur5.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur5/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/load_ur5e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5e.launch.xml
@@ -7,7 +7,7 @@
   <arg name="visual_params" default="$(find ur_description)/config/ur5e/visual_parameters.yaml"/>
 
   <!--Common parameters -->
-  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
+  <arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface" doc="The hardware_interface to expose for each joint in the simulated robot (one of: [PositionJointInterface, VelocityJointInterface, EffortJointInterface])"/>
   <arg name="safety_limits" default="false" doc="If True, enable the safety limits controller"/>
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />

--- a/ur_gazebo/launch/inc/ur_control.launch.xml
+++ b/ur_gazebo/launch/inc/ur_control.launch.xml
@@ -17,8 +17,8 @@
 
   <!-- Parameters we share with ur_robot_driver -->
   <arg name="controller_config_file" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller"/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller"/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller"/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller"/>
 
   <!-- Gazebo parameters -->
   <arg name="gazebo_model_name" default="robot" doc="The name to give to the model in Gazebo (after spawning it)." />

--- a/ur_gazebo/launch/ur10_bringup.launch
+++ b/ur_gazebo/launch/ur10_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur10_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur10e_bringup.launch
+++ b/ur_gazebo/launch/ur10e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur10e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur16e_bringup.launch
+++ b/ur_gazebo/launch/ur16e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur16e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur3_bringup.launch
+++ b/ur_gazebo/launch/ur3_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur3_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur3e_bringup.launch
+++ b/ur_gazebo/launch/ur3e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur3e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur5_bringup.launch
+++ b/ur_gazebo/launch/ur5_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur5_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/launch/ur5e_bringup.launch
+++ b/ur_gazebo/launch/ur5e_bringup.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur5e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller eff_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/urdf/ur.xacro
+++ b/ur_gazebo/urdf/ur.xacro
@@ -45,7 +45,7 @@
     NOTE: this value must correspond to the controller configured in the
           controller .yaml files in the 'config' directory.
   -->
-  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/EffortJointInterface"/>
   <xacro:arg name="safety_limits" default="false"/>
   <xacro:arg name="safety_pos_margin" default="0.15"/>
   <xacro:arg name="safety_k_position" default="20"/>

--- a/ur_gazebo/urdf/ur_macro.xacro
+++ b/ur_gazebo/urdf/ur_macro.xacro
@@ -46,7 +46,7 @@
    kinematics_parameters_file
    physical_parameters_file
    visual_parameters_file
-   transmission_hw_interface:=hardware_interface/PositionJointInterface
+   transmission_hw_interface:=hardware_interface/EffortJointInterface
    safety_limits:=false safety_pos_margin:=0.15 safety_k_position:=20"
   >
     <!--


### PR DESCRIPTION
This is a work in progress. I am working on improving the Gazebo PID parameters for all the robots.

This is based on #525 as for now I will focus on tuning them with the standard cylinder approximation of the links. Once we are sure that the intertia matrices of #504 are correct and this will be merged I will check again if the performance is still ok or if the PID params need re tuning.   

Update PID parameters of:

- [x] ur3
- [x] ur5
- [x] ur10
- [x] ur3e
- [x] ur5e
- [x] ur10e
- [x] ur16e


I am tuning the params at the best of my knowledge, if some has any advice on how to this better let me know. 

This is what I did for the UR10:

I wrote a small ROS node to publish sinusoidal or step inputs to the different joints of the robot, it looks ugly but it does the job:
```
#!/usr/bin/env python
import math, time
import rospy
from trajectory_msgs.msg import JointTrajectoryPoint, JointTrajectory
from std_msgs.msg import Header

class JT:
    def __init__(self):
        rospy.init_node('joint_trajectory_pub')
        self.rate = rospy.Rate(50)

        # Publisher to JointTrajectory robot controller
        self.jt_pub = rospy.Publisher('/eff_joint_traj_controller/command', JointTrajectory, queue_size=10)


    def joint_trajectory_publisher(self):

        i =0 

        while not rospy.is_shutdown():

            msg = JointTrajectory()
            msg.header = Header()
            # msg.joint_names = ["elbow_joint", "shoulder_lift_joint", "shoulder_pan_joint", \
                                # "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"]
            msg.joint_names = ["shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", \
                                "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"]                                
            msg.points=[JointTrajectoryPoint()]
            
            # shoulder_pan_joint
            # sinewave =  0.5 * math.sin(2 * math.pi * 0.5  *time.time())
            # msg.points[0].positions = [sinewave,0.0,0.0,0.0,0.0,0.0]

            # shoulder lift joint
            # sinewave =  -1.57 + 0.5 * math.sin(2 * math.pi * 0.5  *time.time())
            # msg.points[0].positions = [0.0,0.0,sinewave,0.0,0.0,0.0]

            # elbow joint
            # sinewave =  0.5 * math.sin(2 * math.pi * 0.5  *time.time())
            # msg.points[0].positions = [0.0,-1.57,sinewave,0.0,0.0,0.0]

            # step function shoulder_pan_joint
            if i > 20 and i < 500:
                msg.points[0].positions = [0.5,0.0,0,0.0,0.0,0.0,0.0]
            else:
                msg.points[0].positions = [0.0,0.0,0.0,0.0,0.0,0.0]

            # step function shoulder_lift_joint
            # if i > 20 and i < 500:
            #     msg.points[0].positions = [0.0,-0.5,0,0.0,0.0,0.0,0.0]
            # else:
            #     msg.points[0].positions = [0.0,0.0,0.0,0.0,0.0,0.0]

            # # step function elbow_joint
            # if i > 20 and i < 500:
            #     msg.points[0].positions = [0.0,-1.57,0.5,0.0,0.0,0.0]
            # else:
            #     msg.points[0].positions = [0.0,-1.57,0.0,0.0,0.0,0.0]

            # step function wrist_1_joint
            # if i > 20 and i < 500:
            #     msg.points[0].positions = [0.0,-1.57,0.0,1.0,0.0,0.0]
            # else:
            #     msg.points[0].positions = [0.0,-1.57,0.0,0.0,0.0,0.0]

            # step function wrist_2_joint
            # if i > 20 and i < 500:
            #     msg.points[0].positions = [0.0,-1.57,0.0,0.0,1.0,0.0]
            # else:
            #     msg.points[0].positions = [0.0,-1.57,0.0,0.0,0.0,0.0]

            # step function wrist_3_joint
            # if i > 20 and i < 500:
            #     msg.points[0].positions = [0.0,-1.57,0.0,0.0,0.0,1.0]
            # else:
            #     msg.points[0].positions = [0.0,-1.57,0.0,0.0,0.0,0.0]

            msg.points[0].time_from_start = rospy.Duration.from_sec(0.1)
            self.jt_pub.publish(msg)
            self.rate.sleep()
            i = i + 1


if __name__ == '__main__':
    try:
        ch = JT()
        ch.joint_trajectory_publisher()
    except rospy.ROSInterruptException:
        pass
```
I then tried my best to improve the response of the controller to sinewaves and step inputs. Here is what I got so far for the UR10:

The wrist_3_joint was not able to mantain the position at all: 
**wrist_3 error response to a 1.0 step input with previous pid params**
![wrist_3_1_0_step_response_std_pid_params](https://user-images.githubusercontent.com/36470989/87162512-52ff5600-c2c6-11ea-8f10-aa1226d77d9f.png)

**wrist_3 error response to a 1.0 step input with proposed pid params**
![wrist_3_1_0_step_response_tuned_pid_params](https://user-images.githubusercontent.com/36470989/87162671-8b9f2f80-c2c6-11ea-988f-4d14b64a9b09.png)


The wrist_2_joint has now a response with smaller amplitude and the oscillation is dampened faster
**wrist_2 error response to a 1.0 step input with previous pid params**
![wrist_2_1_0_step_response_std_pid_params](https://user-images.githubusercontent.com/36470989/87162877-d1f48e80-c2c6-11ea-8749-eed692dfc279.png)

**wrist_2 error response to a 1.0 step input with proposed pid params**

![wrist_2_1_0_step_response_tuned_pid_params](https://user-images.githubusercontent.com/36470989/87163034-09fbd180-c2c7-11ea-99f7-9e90c69ed8d5.png)

Wrist 1 was not modified. 

The elbow step response oscillation is now dampened faster
**elbow error response to a 1.0 step input with previous pid params**
![elbow_1_0_step_response_std_pid_params](https://user-images.githubusercontent.com/36470989/87163246-57783e80-c2c7-11ea-9e46-3c997b034c7f.png)

**elbow error response to a 1.0 step input with proposed pid params**
![elbow_1_0_step_response_tuned_pid_params](https://user-images.githubusercontent.com/36470989/87163300-69f27800-c2c7-11ea-8a0b-039f3cff87c5.png)

The shoulder_lift step response oscillation is now dampened faster

**shoulder_lift error response to a 1.0 step input with previous pid params**
![shoulder_lift_1_0_step_response_std_pid_params](https://user-images.githubusercontent.com/36470989/87163432-a2925180-c2c7-11ea-9f71-bf1ae73a8fcf.png)

**shoulder_lift error response to a 1.0 step input with proposed pid params**
![shoulder_lift_1_0_step_response_tuned_pid_params](https://user-images.githubusercontent.com/36470989/87163487-bc339900-c2c7-11ea-8996-9bd4fd9e9d2a.png)

The shoulder_pan step response oscillation is now dampened faster, I apologize but I lost the plots of it. 

I am sorry if the plots are not the best, and maybe a bit confusing given the different axis scales but I hope it shows the improvement. 

@gavanderhoorn @fmauch let me know what do you think about this. 
