### PR TITLE
Add transmission_hw_interface to URe xacro and expose everywhere

### DIFF
--- a/ur_e_description/launch/ur10e_upload.launch
+++ b/ur_e_description/launch/ur10e_upload.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="limited" default="false" doc="If true, limits joint range [-PI, PI] on all joints." />
-  
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur10e_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur10e_joint_limited_robot.urdf.xacro'" />
+  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur10e_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur10e_joint_limited_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
 </launch>

--- a/ur_e_description/launch/ur3e_upload.launch
+++ b/ur_e_description/launch/ur3e_upload.launch
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="limited" default="false" doc="If true, limits joint range [-PI, PI] on all joints." />
-  
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur3e_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur3e_joint_limited_robot.urdf.xacro'" />
+  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+
+
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur3e_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur3e_joint_limited_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
 </launch>

--- a/ur_e_description/launch/ur5e_upload.launch
+++ b/ur_e_description/launch/ur5e_upload.launch
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="limited" default="false" doc="If true, limits joint range [-PI, PI] on all joints." />
-  
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur5e_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur5e_joint_limited_robot.urdf.xacro'" />
+  <arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur5e_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_e_description)/urdf/ur5e_joint_limited_robot.urdf.xacro' transmission_hw_interface:=$(arg transmission_hw_interface)" />
 </launch>

--- a/ur_e_description/urdf/ur.transmission.xacro
+++ b/ur_e_description/urdf/ur.transmission.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="ur_arm_transmission" params="prefix">
+  <xacro:macro name="ur_arm_transmission" params="prefix hw_interface">
 
     <transmission name="${prefix}shoulder_pan_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_pan_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_pan_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -16,7 +16,7 @@
     <transmission name="${prefix}shoulder_lift_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}shoulder_lift_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}shoulder_lift_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -26,7 +26,7 @@
     <transmission name="${prefix}elbow_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}elbow_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}elbow_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -36,7 +36,7 @@
     <transmission name="${prefix}wrist_1_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_1_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_1_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -46,7 +46,7 @@
     <transmission name="${prefix}wrist_2_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_2_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_2_motor">
         <mechanicalReduction>1</mechanicalReduction>
@@ -56,7 +56,7 @@
     <transmission name="${prefix}wrist_3_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}wrist_3_joint">
-        <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
+        <hardwareInterface>${hw_interface}</hardwareInterface>
       </joint>
       <actuator name="${prefix}wrist_3_motor">
         <mechanicalReduction>1</mechanicalReduction>

--- a/ur_e_description/urdf/ur10e.urdf.xacro
+++ b/ur_e_description/urdf/ur10e.urdf.xacro
@@ -339,7 +339,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}"/>
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
     <!-- ROS base_link to UR 'Base' Coordinates transform -->

--- a/ur_e_description/urdf/ur10e_joint_limited_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur10e_joint_limited_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur10e" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_e_description)/urdf/common.gazebo.xacro" />
 
@@ -16,6 +18,7 @@
 		 wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
 		 wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
 		 wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+     transmission_hw_interface="$(arg transmission_hw_interface)"
 />
 
   <link name="world" />

--- a/ur_e_description/urdf/ur10e_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur10e_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur10e" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_e_description)/urdf/common.gazebo.xacro" />
 
@@ -9,7 +11,9 @@
   <xacro:include filename="$(find ur_e_description)/urdf/ur10e.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:ur10e_robot prefix="" joint_limited="false"/>
+  <xacro:ur10e_robot prefix="" joint_limited="false"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+  />
 
   <link name="world" />
 

--- a/ur_e_description/urdf/ur3e.urdf.xacro
+++ b/ur_e_description/urdf/ur3e.urdf.xacro
@@ -338,7 +338,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
     <!-- ROS base_link to UR 'Base' Coordinates transform -->

--- a/ur_e_description/urdf/ur3e_joint_limited_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur3e_joint_limited_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur3e" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_e_description)/urdf/common.gazebo.xacro" />
 
@@ -16,6 +18,7 @@
     wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
     wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
     wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
   />
 
   <link name="world" />

--- a/ur_e_description/urdf/ur3e_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur3e_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur3e" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_e_description)/urdf/common.gazebo.xacro" />
 
@@ -9,7 +11,9 @@
   <xacro:include filename="$(find ur_e_description)/urdf/ur3e.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:ur3e_robot prefix="" joint_limited="false"/>
+  <xacro:ur3e_robot prefix="" joint_limited="false"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+  />
 
   <link name="world" />
 

--- a/ur_e_description/urdf/ur5e.urdf.xacro
+++ b/ur_e_description/urdf/ur5e.urdf.xacro
@@ -355,7 +355,7 @@
       </collision>
     </link>
 
-    <xacro:ur_arm_transmission prefix="${prefix}" />
+    <xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />
     <xacro:ur_arm_gazebo prefix="${prefix}" />
 
     <!-- ROS base_link to UR 'Base' Coordinates transform -->

--- a/ur_e_description/urdf/ur5e_joint_limited_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur5e_joint_limited_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur5e" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_e_description)/urdf/common.gazebo.xacro" />
 
@@ -16,6 +18,7 @@
     wrist_1_lower_limit="${-pi}" wrist_1_upper_limit="${pi}"
     wrist_2_lower_limit="${-pi}" wrist_2_upper_limit="${pi}"
     wrist_3_lower_limit="${-pi}" wrist_3_upper_limit="${pi}"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
   />
 
   <link name="world" />

--- a/ur_e_description/urdf/ur5e_robot.urdf.xacro
+++ b/ur_e_description/urdf/ur5e_robot.urdf.xacro
@@ -2,6 +2,8 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro"
        name="ur5e" >
 
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
   <!-- common stuff -->
   <xacro:include filename="$(find ur_e_description)/urdf/common.gazebo.xacro" />
 
@@ -9,7 +11,9 @@
   <xacro:include filename="$(find ur_e_description)/urdf/ur5e.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:ur5e_robot prefix="" joint_limited="false"/>
+  <xacro:ur5e_robot prefix="" joint_limited="false"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+  />
 
   <link name="world" />
 


### PR DESCRIPTION
Adds the capability to select the hardware interface used in the `<transmission>` elements in the URDF model. This allows creating custom simulation setups with different hardware interfaces, e.g. `hardware_interface/VelocityJointInterface`.

Same changes compared with #392, applying to all URe models in this case.