### PR TITLE
description: spec limits in degrees.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,9 @@ env:
   global:
     - CCACHE_DIR=$HOME/.ccache
   matrix:
-    - ROS_DISTRO="kinetic" ROS_REPO=main
-    - ROS_DISTRO="kinetic" ROS_REPO=testing
-    - ROS_DISTRO="kinetic" PRERELEASE=true
-    - ROS_DISTRO="melodic" ROS_REPO=main UPSTREAM_WORKSPACE='github:ros-industrial/ur_msgs@1.3.1'
+    - ROS_DISTRO="melodic" ROS_REPO=main 
     - ROS_DISTRO="melodic" ROS_REPO=testing
-    - ROS_DISTRO="melodic" PRERELEASE=true UPSTREAM_WORKSPACE='github:ros-industrial/ur_msgs@1.3.1'
-
-matrix:
-  allow_failures:
-    - env: ROS_DISTRO="kinetic" ROS_REPO=main
-    - env: ROS_DISTRO="kinetic" ROS_REPO=testing
-    - env: ROS_DISTRO="kinetic" PRERELEASE=true
+    - ROS_DISTRO="melodic" PRERELEASE=true
 
 install:
   - git clone --quiet --depth=1 -b master https://github.com/ros-industrial/industrial_ci.git .industrial_ci

--- a/ur_description/config/ur10/joint_limits.yaml
+++ b/ur_description/config/ur10/joint_limits.yaml
@@ -15,9 +15,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 330.0
-    max_position: 6.28318530718
-    max_velocity: 2.0943951
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  120.0
+    min_position: !degrees -360.0
   shoulder_lift:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -25,9 +25,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 330.0
-    max_position: 6.28318530718
-    max_velocity: 2.0943951
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  120.0
+    min_position: !degrees -360.0
   elbow_joint:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -45,9 +45,9 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: 3.14159265359
-    max_velocity: 3.14159265359
-    min_position: -3.14159265359
+    max_position: !degrees  180.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -180.0
   wrist_1:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -55,9 +55,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_2:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -65,9 +65,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_3:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -75,6 +75,6 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0

--- a/ur_description/config/ur10e/joint_limits.yaml
+++ b/ur_description/config/ur10e/joint_limits.yaml
@@ -15,9 +15,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 330.0
-    max_position: 6.28318530718
-    max_velocity: 2.0943951
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  120.0
+    min_position: !degrees -360.0
   shoulder_lift:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -25,9 +25,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 330.0
-    max_position: 6.28318530718
-    max_velocity: 2.0943951
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  120.0
+    min_position: !degrees -360.0
   elbow_joint:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -45,9 +45,9 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: 3.14159265359
-    max_velocity: 3.14159265359
-    min_position: -3.14159265359
+    max_position: !degrees  180.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -180.0
   wrist_1:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -55,9 +55,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_2:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -65,9 +65,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_3:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -75,6 +75,6 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0

--- a/ur_description/config/ur16e/joint_limits.yaml
+++ b/ur_description/config/ur16e/joint_limits.yaml
@@ -15,9 +15,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 330.0
-    max_position: 6.28318530718
-    max_velocity: 2.0943951
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  120.0
+    min_position: !degrees -360.0
   shoulder_lift:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -25,9 +25,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 330.0
-    max_position: 6.28318530718
-    max_velocity: 2.0943951
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  120.0
+    min_position: !degrees -360.0
   elbow_joint:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -45,9 +45,9 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: 3.14159265359
-    max_velocity: 3.14159265359
-    min_position: -3.14159265359
+    max_position: !degrees  180.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -180.0
   wrist_1:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -55,9 +55,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_2:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -65,9 +65,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_3:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -75,6 +75,6 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0

--- a/ur_description/config/ur3/joint_limits.yaml
+++ b/ur_description/config/ur3/joint_limits.yaml
@@ -15,9 +15,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   shoulder_lift:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -25,9 +25,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   elbow_joint:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -45,9 +45,9 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: 3.14159265359
-    max_velocity: 3.14159265359
-    min_position: -3.14159265359
+    max_position: !degrees  180.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -180.0
   wrist_1:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -55,9 +55,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 12.0
-    max_position: 6.28318530718
-    max_velocity: 6.28318530718
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  360.0
+    min_position: !degrees -360.0
   wrist_2:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -65,9 +65,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 12.0
-    max_position: 6.28318530718
-    max_velocity: 6.28318530718
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  360.0
+    min_position: !degrees -360.0
   wrist_3:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -75,6 +75,6 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 12.0
-    max_position: 6.28318530718
-    max_velocity: 6.28318530718
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  360.0
+    min_position: !degrees -360.0

--- a/ur_description/config/ur3e/joint_limits.yaml
+++ b/ur_description/config/ur3e/joint_limits.yaml
@@ -15,9 +15,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   shoulder_lift:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -25,9 +25,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 56.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   elbow_joint:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -45,9 +45,9 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: 3.14159265359
-    max_velocity: 3.14159265359
-    min_position: -3.14159265359
+    max_position: !degrees  180.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -180.0
   wrist_1:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -55,9 +55,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 12.0
-    max_position: 6.28318530718
-    max_velocity: 6.28318530718
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  360.0
+    min_position: !degrees -360.0
   wrist_2:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -65,9 +65,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 12.0
-    max_position: 6.28318530718
-    max_velocity: 6.28318530718
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  360.0
+    min_position: !degrees -360.0
   wrist_3:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -75,6 +75,6 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 12.0
-    max_position: 6.28318530718
-    max_velocity: 6.28318530718
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  360.0
+    min_position: !degrees -360.0

--- a/ur_description/config/ur5/joint_limits.yaml
+++ b/ur_description/config/ur5/joint_limits.yaml
@@ -15,9 +15,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 150.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   shoulder_lift:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -25,9 +25,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 150.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   elbow_joint:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -45,9 +45,9 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: 3.14159265359
-    max_velocity: 3.14159265359
-    min_position: -3.14159265359
+    max_position: !degrees  180.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -180.0
   wrist_1:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -55,9 +55,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 28.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_2:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -65,9 +65,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 28.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_3:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -75,6 +75,6 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 28.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0

--- a/ur_description/config/ur5e/joint_limits.yaml
+++ b/ur_description/config/ur5e/joint_limits.yaml
@@ -15,9 +15,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 150.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   shoulder_lift:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -25,9 +25,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 150.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   elbow_joint:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -45,9 +45,9 @@ joint_limits:
     #
     # Refer to https://github.com/ros-industrial/universal_robot/issues/265 for
     # more information.
-    max_position: 3.14159265359
-    max_velocity: 3.14159265359
-    min_position: -3.14159265359
+    max_position: !degrees  180.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -180.0
   wrist_1:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -55,9 +55,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 28.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_2:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -65,9 +65,9 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 28.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0
   wrist_3:
     # acceleration limits are not publicly available
     has_acceleration_limits: false
@@ -75,6 +75,6 @@ joint_limits:
     has_position_limits: true
     has_velocity_limits: true
     max_effort: 28.0
-    max_position: 6.28318530718
-    max_velocity: 3.14159265359
-    min_position: -6.28318530718
+    max_position: !degrees  360.0
+    max_velocity: !degrees  180.0
+    min_position: !degrees -360.0


### PR DESCRIPTION
Both `rosparam` ([wiki page](http://wiki.ros.org/rosparam#YAML_Format)) and `xacro` (with ros/xacro#252 merged) support special yaml constructors which allow conversion of numeric values to radians on-the-fly.

This makes it possible for us to specify joint limits in the `config/urXX/joint_limits.yaml` files in degrees, which are much more human readable and easier to compare to the spec sheets.
