### PR TITLE
[ur_msgs] Fix domain constants in Analog.msg

### DIFF
--- a/ur_msgs/msg/Analog.msg
+++ b/ur_msgs/msg/Analog.msg
@@ -1,5 +1,5 @@
-uint8 VOLTAGE=0
-uint8 CURRENT=1
+uint8 CURRENT=0
+uint8 VOLTAGE=1
 
 uint8 pin
 uint8 domain # can be VOLTAGE or CURRENT


### PR DESCRIPTION
CURRENT and VOLTAGE should be inverted.

Tested with URSoftware 3.8.0.61336.

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>