### PR TITLE
Return all IK solutions with MoveIt plugin

### DIFF
--- a/ur_kinematics/CMakeLists.txt
+++ b/ur_kinematics/CMakeLists.txt
@@ -77,3 +77,18 @@ install(DIRECTORY include/${PROJECT_NAME}/
 install(FILES ur_moveit_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+#############
+## Testing ##
+#############
+if(${CATKIN_ENABLE_TESTING})
+  find_package(rostest REQUIRED)
+  add_rostest_gtest(utest
+    test/kinematics_plugin.test
+    test/utest.cpp
+  )
+  target_link_libraries(utest
+    ${catkin_LIBRARIES}
+    ur5_moveit_plugin
+  )
+endif()

--- a/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
+++ b/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
@@ -153,6 +153,12 @@ namespace ur_kinematics
                                   moveit_msgs::MoveItErrorCodes &error_code,
                                   const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
 
+     virtual bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
+                                const std::vector<double>& ik_seed_state,
+                                std::vector<std::vector<double> >& solutions,
+                                kinematics::KinematicsResult& result,
+                                const kinematics::KinematicsQueryOptions& options) const;
+
     virtual bool getPositionFK(const std::vector<std::string> &link_names,
                                const std::vector<double> &joint_angles,
                                std::vector<geometry_msgs::Pose> &poses) const;

--- a/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
+++ b/ur_kinematics/include/ur_kinematics/ur_moveit_plugin.h
@@ -119,14 +119,20 @@ namespace ur_kinematics
                                const std::vector<double> &ik_seed_state,
                                std::vector<double> &solution,
                                moveit_msgs::MoveItErrorCodes &error_code,
-                               const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+                               const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
+
+    virtual bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
+                               const std::vector<double>& ik_seed_state,
+                               std::vector<std::vector<double> >& solutions,
+                               kinematics::KinematicsResult& result,
+                               const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
 
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
                                   double timeout,
                                   std::vector<double> &solution,
                                   moveit_msgs::MoveItErrorCodes &error_code,
-                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
 
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
@@ -134,7 +140,7 @@ namespace ur_kinematics
                                   const std::vector<double> &consistency_limits,
                                   std::vector<double> &solution,
                                   moveit_msgs::MoveItErrorCodes &error_code,
-                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
 
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
@@ -142,7 +148,7 @@ namespace ur_kinematics
                                   std::vector<double> &solution,
                                   const IKCallbackFn &solution_callback,
                                   moveit_msgs::MoveItErrorCodes &error_code,
-                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
 
     virtual bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
                                   const std::vector<double> &ik_seed_state,
@@ -151,35 +157,52 @@ namespace ur_kinematics
                                   std::vector<double> &solution,
                                   const IKCallbackFn &solution_callback,
                                   moveit_msgs::MoveItErrorCodes &error_code,
-                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
-
-     virtual bool getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
-                                const std::vector<double>& ik_seed_state,
-                                std::vector<std::vector<double> >& solutions,
-                                kinematics::KinematicsResult& result,
-                                const kinematics::KinematicsQueryOptions& options) const;
+                                  const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
 
     virtual bool getPositionFK(const std::vector<std::string> &link_names,
                                const std::vector<double> &joint_angles,
-                               std::vector<geometry_msgs::Pose> &poses) const;
+                               std::vector<geometry_msgs::Pose> &poses) const override;
 
     virtual bool initialize(const std::string &robot_description,
                             const std::string &group_name,
                             const std::string &base_name,
                             const std::string &tip_name,
-                            double search_discretization);
+                            double search_discretization) override;
 
     /**
 * @brief Return all the joint names in the order they are used internally
 */
-    const std::vector<std::string>& getJointNames() const;
+    const std::vector<std::string>& getJointNames() const override;
 
     /**
 * @brief Return all the link names in the order they are represented internally
 */
-    const std::vector<std::string>& getLinkNames() const;
+    const std::vector<std::string>& getLinkNames() const override;
 
   protected:
+
+  /**
+* @brief Searches for all valid joint solutions capable of achieving a given desired pose of the end-effector,
+* This particular method is intended for "searching" for multiple IK solutions by stepping through the redundancy
+* (or other numerical routines).
+* @param ik_pose the desired pose of the link
+* @param ik_seed_state an initial guess solution for the inverse kinematics
+* @param timeout The amount of time (in seconds) available to the solver
+* @param solutions the vector of valid joint state IK solutions
+* @param solution_callback A callback solution for the IK solution
+* @param error_code an error code that encodes the reason for failure or success
+* @param consistency_limit The returned solutuion will contain a value for the redundant joint in the range [seed_state(redundancy_limit)-consistency_limit,seed_state(redundancy_limit)+consistency_limit]
+* @return True if a valid solution was found, false otherwise
+ */
+    bool searchPositionIK(const geometry_msgs::Pose &ik_pose,
+                          const std::vector<double> &ik_seed_state,
+                          double timeout,
+                          std::vector<std::vector<double>> &solution,
+                          const IKCallbackFn &solution_callback,
+                          moveit_msgs::MoveItErrorCodes &error_code,
+                          const std::vector<double> &consistency_limits,
+                          const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
+
 
   /**
 * @brief Given a desired pose of the end-effector, search for the joint angles required to reach it.
@@ -191,8 +214,6 @@ namespace ur_kinematics
 * @param solution the solution vector
 * @param solution_callback A callback solution for the IK solution
 * @param error_code an error code that encodes the reason for failure or success
-* @param check_consistency Set to true if consistency check needs to be performed
-* @param redundancy The index of the redundant joint
 * @param consistency_limit The returned solutuion will contain a value for the redundant joint in the range [seed_state(redundancy_limit)-consistency_limit,seed_state(redundancy_limit)+consistency_limit]
 * @return True if a valid solution was found, false otherwise
 */
@@ -205,7 +226,7 @@ namespace ur_kinematics
                           const std::vector<double> &consistency_limits,
                           const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const;
 
-    virtual bool setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices);
+    virtual bool setRedundantJoints(const std::vector<unsigned int> &redundant_joint_indices) override;
 
   private:
 

--- a/ur_kinematics/package.xml
+++ b/ur_kinematics/package.xml
@@ -29,6 +29,8 @@
 
   <exec_depend>rospy</exec_depend>
 
+  <test_depend>rostest</test_depend>
+
   <export>
     <moveit_core plugin="${prefix}/ur_moveit_plugins.xml"/>
   </export>

--- a/ur_kinematics/src/ur_moveit_plugin.cpp
+++ b/ur_kinematics/src/ur_moveit_plugin.cpp
@@ -138,7 +138,7 @@ void URKinematicsPlugin::getRandomConfiguration(const KDL::JntArray &seed_state,
   }
 
   joint_model_group_->getVariableRandomPositionsNearBy(state_->getRandomNumberGenerator(), values, near, consistency_limits_mimic);
-  
+
   for (std::size_t i = 0; i < dimension_; ++i)
   {
     bool skip = false;
@@ -188,7 +188,7 @@ bool URKinematicsPlugin::initialize(const std::string &robot_description,
   robot_model::JointModelGroup* joint_model_group = robot_model_->getJointModelGroup(group_name);
   if (!joint_model_group)
     return false;
-  
+
   if(!joint_model_group->isChain())
   {
     ROS_ERROR_NAMED("kdl","Group '%s' is not a chain", group_name.c_str());
@@ -267,7 +267,7 @@ bool URKinematicsPlugin::initialize(const std::string &robot_description,
   for (std::size_t i = 0; i < kdl_chain_.getNrOfSegments(); ++i)
   {
     const robot_model::JointModel *jm = robot_model_->getJointModel(kdl_chain_.segments[i].getJoint().getName());
-    
+
     //first check whether it belongs to the set of active joints in the group
     if (jm->getMimic() == NULL && jm->getVariableCount() > 0)
     {
@@ -345,14 +345,14 @@ bool URKinematicsPlugin::initialize(const std::string &robot_description,
   for(int i=1; i<6; i++) {
     cur_ur_joint_ind = getJointIndex(ur_joint_names_[i]);
     if(cur_ur_joint_ind < 0) {
-      ROS_ERROR_NAMED("kdl", 
-        "Kin chain provided in model doesn't contain standard UR joint '%s'.", 
+      ROS_ERROR_NAMED("kdl",
+        "Kin chain provided in model doesn't contain standard UR joint '%s'.",
         ur_joint_names_[i].c_str());
       return false;
     }
     if(cur_ur_joint_ind != last_ur_joint_ind + 1) {
-      ROS_ERROR_NAMED("kdl", 
-        "Kin chain provided in model doesn't have proper serial joint order: '%s'.", 
+      ROS_ERROR_NAMED("kdl",
+        "Kin chain provided in model doesn't have proper serial joint order: '%s'.",
         ur_joint_names_[i].c_str());
       return false;
     }
@@ -628,7 +628,7 @@ bool URKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
     // Convert into query for analytic solver
     tf::poseMsgToKDL(ik_pose, kdl_ik_pose);
     kdl_ik_pose_ur_chain = pose_base.Inverse() * kdl_ik_pose * pose_tip.Inverse();
-    
+
     kdl_ik_pose_ur_chain.Make4x4((double*) homo_ik_pose);
 #if KDL_OLD_BUG_FIX
     // in older versions of KDL, setting this flag might be necessary
@@ -637,10 +637,10 @@ bool URKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
     /////////////////////////////////////////////////////////////////////////////
 
     // Do the analytic IK
-    num_sols = inverse((double*) homo_ik_pose, (double*) q_ik_sols, 
+    num_sols = inverse((double*) homo_ik_pose, (double*) q_ik_sols,
                        jnt_pos_test(ur_joint_inds_start_+5));
-    
-    
+
+
     uint16_t num_valid_sols;
     std::vector< std::vector<double> > q_ik_valid_sols;
     for(uint16_t i=0; i<num_sols; i++)
@@ -648,11 +648,11 @@ bool URKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
       bool valid = true;
       std::vector< double > valid_solution;
       valid_solution.assign(6,0.0);
-      
+
       for(uint16_t j=0; j<6; j++)
       {
         if((q_ik_sols[i][j] <= ik_chain_info_.limits[j].max_position) && (q_ik_sols[i][j] >= ik_chain_info_.limits[j].min_position))
-        { 
+        {
           valid_solution[j] = q_ik_sols[i][j];
           valid = true;
           continue;
@@ -675,14 +675,14 @@ bool URKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
           break;
         }
       }
-      
+
       if(valid)
       {
         q_ik_valid_sols.push_back(valid_solution);
       }
     }
-     
-     
+
+
     // use weighted absolute deviations to determine the solution closest the seed state
     std::vector<idx_double> weighted_diffs;
     for(uint16_t i=0; i<q_ik_valid_sols.size(); i++) {
@@ -763,6 +763,151 @@ bool URKinematicsPlugin::searchPositionIK(const geometry_msgs::Pose &ik_pose,
     } else {
       getRandomConfiguration(jnt_pos_test, false);
     }
+  }
+
+  ROS_DEBUG_NAMED("kdl","An IK that satisifes the constraints and is collision free could not be found");
+  error_code.val = error_code.NO_IK_SOLUTION;
+  return false;
+}
+
+bool URKinematicsPlugin::getPositionIK(const std::vector<geometry_msgs::Pose>& ik_poses,
+                                       const std::vector<double>& ik_seed_state,
+                                       std::vector<std::vector<double> >& solutions,
+                                       kinematics::KinematicsResult& result,
+                                       const kinematics::KinematicsQueryOptions& options) const
+{
+  double timeout = 30.0f;
+  moveit_msgs::MoveItErrorCodes error_code;
+  std::vector<double> consistency_limits;
+
+  ros::WallTime n1 = ros::WallTime::now();
+  if(!active_) {
+    ROS_ERROR_NAMED("kdl","kinematics not active");
+    error_code.val = error_code.NO_IK_SOLUTION;
+    return false;
+  }
+
+  if(ik_seed_state.size() != dimension_) {
+    ROS_ERROR_STREAM_NAMED("kdl","Seed state must have size " << dimension_ << " instead of size " << ik_seed_state.size());
+    error_code.val = error_code.NO_IK_SOLUTION;
+    return false;
+  }
+
+  if(!consistency_limits.empty() && consistency_limits.size() != dimension_) {
+    ROS_ERROR_STREAM_NAMED("kdl","Consistency limits be empty or must have size " << dimension_ << " instead of size " << consistency_limits.size());
+    error_code.val = error_code.NO_IK_SOLUTION;
+    return false;
+  }
+
+  KDL::JntArray jnt_seed_state(dimension_);
+  for(int i=0; i<dimension_; i++)
+    jnt_seed_state(i) = ik_seed_state[i];
+
+  // Made a dummy solution
+  std::vector<double> solution;
+  solution.resize(dimension_);
+
+  KDL::ChainFkSolverPos_recursive fk_solver_base(kdl_base_chain_);
+  KDL::ChainFkSolverPos_recursive fk_solver_tip(kdl_tip_chain_);
+
+  KDL::JntArray jnt_pos_test(jnt_seed_state);
+  KDL::JntArray jnt_pos_base(ur_joint_inds_start_);
+  KDL::JntArray jnt_pos_tip(dimension_ - 6 - ur_joint_inds_start_);
+  KDL::Frame pose_base, pose_tip;
+
+  KDL::Frame kdl_ik_pose;
+  KDL::Frame kdl_ik_pose_ur_chain;
+  double homo_ik_pose[4][4];
+  double q_ik_sols[8][6]; // maximum of 8 IK solutions
+  uint16_t num_sols;
+
+  while(1) {
+    if(timedOut(n1, timeout)) {
+      ROS_DEBUG_NAMED("kdl","IK timed out");
+      error_code.val = error_code.TIMED_OUT;
+      return false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // find transformation from robot base to UR base and UR tip to robot tip
+    for(uint32_t i=0; i<jnt_pos_base.rows(); i++)
+      jnt_pos_base(i) = jnt_pos_test(i);
+    for(uint32_t i=0; i<jnt_pos_tip.rows(); i++)
+      jnt_pos_tip(i) = jnt_pos_test(i + ur_joint_inds_start_ + 6);
+    for(uint32_t i=0; i<jnt_seed_state.rows(); i++)
+      solution[i] = jnt_pos_test(i);
+
+    if(fk_solver_base.JntToCart(jnt_pos_base, pose_base) < 0) {
+      ROS_ERROR_NAMED("kdl", "Could not compute FK for base chain");
+      return false;
+    }
+
+    if(fk_solver_tip.JntToCart(jnt_pos_tip, pose_tip) < 0) {
+      ROS_ERROR_NAMED("kdl", "Could not compute FK for tip chain");
+      return false;
+    }
+    /////////////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Convert into query for analytic solver
+    tf::poseMsgToKDL(ik_poses.front(), kdl_ik_pose);
+    kdl_ik_pose_ur_chain = pose_base.Inverse() * kdl_ik_pose * pose_tip.Inverse();
+
+    kdl_ik_pose_ur_chain.Make4x4((double*) homo_ik_pose);
+#if KDL_OLD_BUG_FIX
+    // in older versions of KDL, setting this flag might be necessary
+    for(int i=0; i<3; i++) homo_ik_pose[i][3] *= 1000; // strange KDL fix
+#endif
+    /////////////////////////////////////////////////////////////////////////////
+
+    // Do the analytic IK
+    num_sols = inverse((double*) homo_ik_pose, (double*) q_ik_sols,
+                       jnt_pos_test(ur_joint_inds_start_+5));
+
+
+    uint16_t num_valid_sols;
+    std::vector< std::vector<double> > q_ik_valid_sols;
+    for(uint16_t i=0; i<num_sols; i++)
+    {
+      bool valid = true;
+      std::vector< double > valid_solution;
+      valid_solution.assign(6,0.0);
+
+      for(uint16_t j=0; j<6; j++)
+      {
+        if((q_ik_sols[i][j] <= ik_chain_info_.limits[j].max_position) && (q_ik_sols[i][j] >= ik_chain_info_.limits[j].min_position))
+        {
+          valid_solution[j] = q_ik_sols[i][j];
+          valid = true;
+          continue;
+        }
+        else if ((q_ik_sols[i][j] > ik_chain_info_.limits[j].max_position) && (q_ik_sols[i][j]-2*M_PI > ik_chain_info_.limits[j].min_position))
+        {
+          valid_solution[j] = q_ik_sols[i][j]-2*M_PI;
+          valid = true;
+          continue;
+        }
+        else if ((q_ik_sols[i][j] < ik_chain_info_.limits[j].min_position) && (q_ik_sols[i][j]+2*M_PI < ik_chain_info_.limits[j].max_position))
+        {
+          valid_solution[j] = q_ik_sols[i][j]+2*M_PI;
+          valid = true;
+          continue;
+        }
+        else
+        {
+          valid = false;
+          break;
+        }
+      }
+
+      if(valid)
+      {
+        q_ik_valid_sols.push_back(valid_solution);
+      }
+    }
+
+    solutions = q_ik_valid_sols;
+    return true;
   }
 
   ROS_DEBUG_NAMED("kdl","An IK that satisifes the constraints and is collision free could not be found");

--- a/ur_kinematics/test/kinematics_plugin.test
+++ b/ur_kinematics/test/kinematics_plugin.test
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+  <include file="$(find ur5_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+  <test test-name="utest" pkg="ur_kinematics" type="utest"/>
+</launch>

--- a/ur_kinematics/test/utest.cpp
+++ b/ur_kinematics/test/utest.cpp
@@ -1,0 +1,71 @@
+#include <ur_kinematics/ur_moveit_plugin.h>
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+void checkNear(const std::vector<double> &state_1,
+               const std::vector<double> &state_2,
+               const double epsilon)
+{
+  for (std::size_t i = 0; i < state_1.size(); ++i)
+  {
+    EXPECT_NEAR(state_1[i], state_2[i], epsilon);
+  }
+}
+
+/** @brief Normalize the joint solution on [-pi, pi] */
+std::vector<double> normalize(const std::vector<double> &joints)
+{
+  std::vector<double> out(joints.size());
+  std::transform(joints.begin(), joints.end(), out.begin(), [](const double jv) {
+    if (jv > M_PI)
+      return -jv + M_PI;
+    else if (jv < -M_PI)
+      return -jv - M_PI;
+    else
+      return jv;
+  });
+  return out;
+}
+
+TEST(URKinematics, MoveItPluginTest)
+{
+  const std::string base_frame = "base_link";
+  const std::string tool_frame = "ee_link";
+  const std::string group = "manipulator";
+
+  ur_kinematics::URKinematicsPlugin plugin;
+  ASSERT_TRUE(plugin.initialize("robot_description", group, base_frame, tool_frame, 0.01));
+
+  // Perform FK for an arbitrary joint state
+  std::vector<double> joint_state = {0.0, -M_PI / 2.0, M_PI / 2.0, 0.0, M_PI / 2.0, 0.0};
+  std::vector<geometry_msgs::Pose> poses;
+  ASSERT_TRUE(plugin.getPositionFK({tool_frame}, joint_state, poses));
+  ASSERT_EQ(poses.size(), 1);
+
+  // Perform IK with the initial joint state as the seed to get a single joint state
+  std::vector<double> solution;
+  moveit_msgs::MoveItErrorCodes error_code;
+  ASSERT_TRUE(plugin.getPositionIK(poses.front(), joint_state, solution, error_code));
+  ASSERT_EQ(error_code.val, moveit_msgs::MoveItErrorCodes::SUCCESS);
+
+  // Check that the normalized joint solution is close the initial state
+  const double eps = 1.0e-6;
+  checkNear(normalize(solution), joint_state, eps);
+
+  // Perform IK with the initial joint state as the seed to get all valid joint states
+  std::vector<std::vector<double>> solutions;
+  kinematics::KinematicsResult result;
+  ASSERT_TRUE(plugin.getPositionIK(poses, joint_state, solutions, result));
+  ASSERT_EQ(solutions.size(), 8);
+
+  // Make sure the first joint state is close to the initial state
+  // The solutions should already be sorted by distance to the seed state, so compare only the first solution
+  checkNear(normalize(solutions.front()), joint_state, eps);
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "utest");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
I have a use case where I would like to use the MoveIt kinematics plugin `getPositionIK` function to return a vector of valid joint solutions for a UR robot. The default implementation of this function in the `KinematicsBase` class simply calls another `getPositionIK` overload to return a single joint position that is closest to the seed state. This PR overrides this function to return all valid joint states, given a single input tool pose. I also created a simple unit test to verify the behavior of the `getPositionFK` and `getPositionIK` functions

In the future, it would also be nice to return the all of the joint solution permutations considering the full [-2 * pi, 2 * pi] range of some of the joints. I wrote some code to do this a while back that I could probably integrate into this plugin if it's valuable