### PR TITLE
ur_description: Use the per-model xacro files for correct robot name

### DIFF
--- a/ur_description/launch/load_ur.launch
+++ b/ur_description/launch/load_ur.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" />
+
   <!-- Load the top-level (ie: stand-alone and complete) xacro for the UR
        variant defined by the set of yaml parameter files (so to load a UR5
        onto the ROS parameter server, provide paths to the .yaml files which
@@ -28,7 +30,7 @@
        include the ur_macro.xacro file into it. Then write a new .launch file
        to load it onto the parameter server.
   -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_description)/urdf/ur.xacro'
+  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_description)/urdf/$(arg robot_model).xacro'
     joint_limit_params:=$(arg joint_limit_params)
     kinematics_params:=$(arg kinematics_params)
     physical_params:=$(arg physical_params)

--- a/ur_description/launch/load_ur10.launch
+++ b/ur_description/launch/load_ur10.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" value="ur10" />
+
   <!-- use common launch file and pass all arguments to it -->
   <include file="$(find ur_description)/launch/load_ur.launch" pass_all_args="true"/>
 </launch>

--- a/ur_description/launch/load_ur10e.launch
+++ b/ur_description/launch/load_ur10e.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" value="ur10e" />
+
   <!-- use common launch file and pass all arguments to it -->
   <include file="$(find ur_description)/launch/load_ur.launch" pass_all_args="true"/>
 </launch>

--- a/ur_description/launch/load_ur16e.launch
+++ b/ur_description/launch/load_ur16e.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" value="ur16e" />
+
   <!-- use common launch file and pass all arguments to it -->
   <include file="$(find ur_description)/launch/load_ur.launch" pass_all_args="true"/>
 </launch>

--- a/ur_description/launch/load_ur3.launch
+++ b/ur_description/launch/load_ur3.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" value="ur3" />
+
   <!-- use common launch file and pass all arguments to it -->
   <include file="$(find ur_description)/launch/load_ur.launch" pass_all_args="true"/>
 </launch>

--- a/ur_description/launch/load_ur3e.launch
+++ b/ur_description/launch/load_ur3e.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" value="ur3e" />
+
   <!-- use common launch file and pass all arguments to it -->
   <include file="$(find ur_description)/launch/load_ur.launch" pass_all_args="true"/>
 </launch>

--- a/ur_description/launch/load_ur5.launch
+++ b/ur_description/launch/load_ur5.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" value="ur5" />
+
   <!-- use common launch file and pass all arguments to it -->
   <include file="$(find ur_description)/launch/load_ur.launch" pass_all_args="true"/>
 </launch>

--- a/ur_description/launch/load_ur5e.launch
+++ b/ur_description/launch/load_ur5e.launch
@@ -11,6 +11,8 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <arg name="robot_model" value="ur5e" />
+
   <!-- use common launch file and pass all arguments to it -->
   <include file="$(find ur_description)/launch/load_ur.launch" pass_all_args="true"/>
 </launch>


### PR DESCRIPTION
With the common xacro file the robot name will always be "ur".
However, the moveit config packages expect the robot name to be e.g. "ur10e".
This commit will use the macros containing the model name already.

This fixes #585 and should help in #538.