### PR TITLE
[ur_description] Allow custom robot

### DIFF
--- a/ur_description/launch/load_ur.launch
+++ b/ur_description/launch/load_ur.launch
@@ -30,11 +30,11 @@
        include the ur_macro.xacro file into it. Then write a new .launch file
        to load it onto the parameter server.
   -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_description)/urdf/$(arg robot_model).xacro'
-    joint_limit_params:=$(arg joint_limit_params)
-    kinematics_params:=$(arg kinematics_params)
-    physical_params:=$(arg physical_params)
-    visual_params:=$(arg visual_params)
+  <param name="robot_description" command="xacro '$(find ur_description)/urdf/$(arg robot_model).xacro'
+    joint_limits_parameters_file:=$(arg joint_limit_params)
+    kinematics_parameters_file:=$(arg kinematics_params)
+    physical_parameters_file:=$(arg physical_params)
+    visual_parameters_file:=$(arg visual_params)
     transmission_hw_interface:=$(arg transmission_hw_interface)
     safety_limits:=$(arg safety_limits)
     safety_pos_margin:=$(arg safety_pos_margin)

--- a/ur_description/urdf/ur10.xacro
+++ b/ur_description/urdf/ur10.xacro
@@ -18,5 +18,14 @@
     Refer to 'inc/ur_macro.xacro' for more information.
   -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur10_macro.xacro"/>
-  <xacro:ur10_robot prefix="" />
+  <xacro:ur10_robot prefix=""
+    joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
+    kinematics_parameters_file="$(arg kinematics_parameters_file)"
+    physical_parameters_file="$(arg physical_parameters_file)"
+    visual_parameters_file="$(arg visual_parameters_file)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+    />
 </robot>

--- a/ur_description/urdf/ur10e.xacro
+++ b/ur_description/urdf/ur10e.xacro
@@ -18,5 +18,14 @@
     Refer to 'inc/ur_macro.xacro' for more information.
   -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur10e_macro.xacro"/>
-  <xacro:ur10e_robot prefix="" />
+  <xacro:ur10e_robot prefix=""
+    joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
+    kinematics_parameters_file="$(arg kinematics_parameters_file)"
+    physical_parameters_file="$(arg physical_parameters_file)"
+    visual_parameters_file="$(arg visual_parameters_file)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+    />
 </robot>

--- a/ur_description/urdf/ur16e.xacro
+++ b/ur_description/urdf/ur16e.xacro
@@ -18,5 +18,14 @@
     Refer to 'inc/ur_macro.xacro' for more information.
   -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur16e_macro.xacro"/>
-  <xacro:ur16e_robot prefix="" />
+  <xacro:ur16e_robot prefix=""
+    joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
+    kinematics_parameters_file="$(arg kinematics_parameters_file)"
+    physical_parameters_file="$(arg physical_parameters_file)"
+    visual_parameters_file="$(arg visual_parameters_file)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+    />
 </robot>

--- a/ur_description/urdf/ur3.xacro
+++ b/ur_description/urdf/ur3.xacro
@@ -18,5 +18,14 @@
     Refer to 'inc/ur_macro.xacro' for more information.
   -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur3_macro.xacro"/>
-  <xacro:ur3_robot prefix="" />
+  <xacro:ur3_robot prefix=""
+    joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
+    kinematics_parameters_file="$(arg kinematics_parameters_file)"
+    physical_parameters_file="$(arg physical_parameters_file)"
+    visual_parameters_file="$(arg visual_parameters_file)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+    />
 </robot>

--- a/ur_description/urdf/ur3e.xacro
+++ b/ur_description/urdf/ur3e.xacro
@@ -18,5 +18,14 @@
     Refer to 'inc/ur_macro.xacro' for more information.
   -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur3e_macro.xacro"/>
-  <xacro:ur3e_robot prefix="" />
+  <xacro:ur3e_robot prefix=""
+    joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
+    kinematics_parameters_file="$(arg kinematics_parameters_file)"
+    physical_parameters_file="$(arg physical_parameters_file)"
+    visual_parameters_file="$(arg visual_parameters_file)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+    />
 </robot>

--- a/ur_description/urdf/ur5.xacro
+++ b/ur_description/urdf/ur5.xacro
@@ -18,5 +18,14 @@
     Refer to 'inc/ur_macro.xacro' for more information.
   -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur5_macro.xacro"/>
-  <xacro:ur5_robot prefix="" />
+  <xacro:ur5_robot prefix=""
+    joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
+    kinematics_parameters_file="$(arg kinematics_parameters_file)"
+    physical_parameters_file="$(arg physical_parameters_file)"
+    visual_parameters_file="$(arg visual_parameters_file)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+    />
 </robot>

--- a/ur_description/urdf/ur5e.xacro
+++ b/ur_description/urdf/ur5e.xacro
@@ -18,5 +18,14 @@
     Refer to 'inc/ur_macro.xacro' for more information.
   -->
   <xacro:include filename="$(find ur_description)/urdf/inc/ur5e_macro.xacro"/>
-  <xacro:ur5e_robot prefix="" />
+  <xacro:ur5e_robot prefix=""
+    joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
+    kinematics_parameters_file="$(arg kinematics_parameters_file)"
+    physical_parameters_file="$(arg physical_parameters_file)"
+    visual_parameters_file="$(arg visual_parameters_file)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+    />
 </robot>


### PR DESCRIPTION
The arguments were missing in `ur10_macro.xacro` and similars, as well
as in `load_ur.launch`

Signed-off-by: Gaël Écorchard <gael.ecorchard@cvut.cz>