### PR TITLE
Add tool0_controller frame for gazebo simulation

### DIFF
--- a/ur_gazebo/urdf/ur.xacro
+++ b/ur_gazebo/urdf/ur.xacro
@@ -77,4 +77,11 @@
     <child link="base_link"/>
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </joint>
+
+  <link name="tool0_controller"/>
+  <joint name="tool_controller_fake_joint" type="fixed">
+    <parent link="tool0"/>
+    <child link="tool0_controller"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
 </robot>


### PR DESCRIPTION
In order to make the simulation more consistent to the ur_robot_driver (and ur_modern_driver) this adds a tool0_controller frame. For the driver this corresponds to the tool transformation published by the robot controller directly. As this doesn't exist for the simulated robot, this adds the frame using an identity transform from tool0.

This basically implements #522 