### PR TITLE
ur_description: Make robot name configurable on load_ur.launch

### DIFF
--- a/ur_description/launch/load_ur.launch
+++ b/ur_description/launch/load_ur.launch
@@ -30,7 +30,8 @@
        include the ur_macro.xacro file into it. Then write a new .launch file
        to load it onto the parameter server.
   -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_description)/urdf/$(arg robot_model).xacro'
+  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_description)/urdf/ur.xacro'
+    robot_model:=$(arg robot_model)
     joint_limit_params:=$(arg joint_limit_params)
     kinematics_params:=$(arg kinematics_params)
     physical_params:=$(arg physical_params)

--- a/ur_description/urdf/ur.xacro
+++ b/ur_description/urdf/ur.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="ur">
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg robot_model)_robot">
 
    <!-- import main macro -->
    <xacro:include filename="$(find ur_description)/urdf/inc/ur_macro.xacro"/>


### PR DESCRIPTION
This is the alternative implementation of #592 as proposed there.

In 9d02ccadc8fb9b5cfeaf0d5b0c0c7708d2461447 robot launchfiles were forwarded to their specialized launchfiles instead of setting the robot model in the load_ur.launch file.