### PR TITLE
Make ur_gazebo robot name consistent with ur_description

### DIFF
--- a/ur_gazebo/launch/inc/load_ur.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur.launch.xml
@@ -18,6 +18,8 @@
        to load it onto the parameter server.
   -->
 
+  <arg name="robot_model" doc="Type/series of used UR robot (ur3, ur3e, ur5, ur5e, ur10, ur10e, ur16e)" />
+
   <!--Parameter files -->
   <arg name="joint_limit_params" doc="YAML file containing the joint limit values"/>
   <arg name="kinematics_params" doc="YAML file containing the robot's kinematic parameters. These will be different for each robot as they contain the robot's calibration."/>
@@ -31,6 +33,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <param name="robot_description" command="$(find xacro)/xacro '$(find ur_gazebo)/urdf/ur.xacro'
+    robot_model:=$(arg robot_model)
     joint_limit_params:=$(arg joint_limit_params)
     kinematics_params:=$(arg kinematics_params)
     physical_params:=$(arg physical_params)

--- a/ur_gazebo/launch/inc/load_ur10.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur10.launch.xml
@@ -13,5 +13,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <!-- Use common launch file and pass all arguments to it -->
-  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
+  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true">
+    <arg name="robot_model" value="ur10" />
+  </include>
 </launch>

--- a/ur_gazebo/launch/inc/load_ur10e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur10e.launch.xml
@@ -13,5 +13,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <!-- Use common launch file and pass all arguments to it -->
-  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
+  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true">
+    <arg name="robot_model" value="ur10e" />
+  </include>
 </launch>

--- a/ur_gazebo/launch/inc/load_ur16e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur16e.launch.xml
@@ -13,5 +13,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <!-- Use common launch file and pass all arguments to it -->
-  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
+  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true">
+    <arg name="robot_model" value="ur16e" />
+  </include>
 </launch>

--- a/ur_gazebo/launch/inc/load_ur3.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur3.launch.xml
@@ -13,5 +13,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <!-- Use common launch file and pass all arguments to it -->
-  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
+  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true">
+    <arg name="robot_model" value="ur3" />
+  </include>
 </launch>

--- a/ur_gazebo/launch/inc/load_ur3e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur3e.launch.xml
@@ -13,5 +13,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <!-- Use common launch file and pass all arguments to it -->
-  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
+  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true">
+    <arg name="robot_model" value="ur3e" />
+  </include>
 </launch>

--- a/ur_gazebo/launch/inc/load_ur5.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5.launch.xml
@@ -13,5 +13,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <!-- Use common launch file and pass all arguments to it -->
-  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
+  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true">
+    <arg name="robot_model" value="ur5" />
+  </include>
 </launch>

--- a/ur_gazebo/launch/inc/load_ur5e.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5e.launch.xml
@@ -13,5 +13,7 @@
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
   <!-- Use common launch file and pass all arguments to it -->
-  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
+  <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true">
+    <arg name="robot_model" value="ur5e" />
+  </include>
 </launch>

--- a/ur_gazebo/urdf/ur.xacro
+++ b/ur_gazebo/urdf/ur.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://wiki.ros.org/xacro" name="ur_robot_gazebo">
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg robot_model)_robot">
   <!--
     This is a top-level xacro instantiating the Gazebo-specific version of the
     'ur_robot' macro (ie: 'ur_robot_gazebo') and passing it values for all its


### PR DESCRIPTION
This fixes the different urdf robot names between the real hardware and ur_gazebo and thereby eliminates a moveit startup error that complains about a name difference between the urdf and srdf.