### PR TITLE
[meta]: Remove ur_kinematics package for now

### DIFF
--- a/universal_robots/package.xml
+++ b/universal_robots/package.xml
@@ -29,7 +29,6 @@
   <exec_depend>ur5_moveit_config</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>ur_gazebo</exec_depend>
-  <exec_depend>ur_kinematics</exec_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
With the dependency we cannot release the metapackage for now, since it is not released.

As stated in #613 @RobertWilbrandt and me discussed to not include `ur_kinematics` in the first melodic/noetic release. However, we then also have to remove it from the metapackage, as we otherwise cannot release it (sorry I didn't think about this earlier).

Alternatively, we would have to also release `ur_kinematics`. Technically, this would work, as the plugin is working in the current state, however, I don't feel comfortable doing this as noted in #613.