### PR TITLE
Added prefix argument to ur.xacro

### DIFF
--- a/ur_description/urdf/ur.xacro
+++ b/ur_description/urdf/ur.xacro
@@ -18,10 +18,11 @@
    <xacro:arg name="safety_limits" default="false"/>
    <xacro:arg name="safety_pos_margin" default="0.15"/>
    <xacro:arg name="safety_k_position" default="20"/>
+   <xacro:arg name="prefix" default=""/>
 
    <!-- arm -->
    <xacro:ur_robot
-     prefix=""
+     prefix="$(arg prefix)"
      joint_limits_parameters_file="$(arg joint_limit_params)"
      kinematics_parameters_file="$(arg kinematics_params)"
      physical_parameters_file="$(arg physical_params)"


### PR DESCRIPTION
There are some use cases where being able to specify the prefix in the non-macro xacro file is useful.

Adding this should have no impact on any existing use cases.

I can add this argument to the other "concrete" xacro files, but I believe in nearly all cases where this is relevant the user will favor using the generic file anyway.

As a side note, this argument is provided in the non-macro file of the [ROS2 description repo](https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/75b5c69b79de206bbf646b681ce345059e01c12b/urdf/ur.urdf.xacro#L13C11-L13C11).