### PR TITLE
Set initial joint at launch gazebo

### DIFF
--- a/ur_gazebo/launch/inc/ur_control.launch.xml
+++ b/ur_gazebo/launch/inc/ur_control.launch.xml
@@ -30,7 +30,7 @@
   <arg name="start_gazebo" default="true" doc="If true, Gazebo will be started. If false, Gazebo will be assumed to have been started elsewhere." />
 
   <!--Setting initial configuration -->
-  <arg name="initial_joint_positions" default=" -J shoulder_pan_joint 0.0  -J shoulder_lift_joint -1.54 -J elbow_joint 1.54 -J wrist_1_joint -1.54 -J wrist_2_joint -1.54 -J wrist_3_joint 0.0" doc="Initial joint configuration of the robot"/>
+  <arg name="initial_joint_positions" default=" -J shoulder_pan_joint 0.0  -J shoulder_lift_joint -1.57 -J elbow_joint 0.0 -J wrist_1_joint -1.57 -J wrist_2_joint 0.0 -J wrist_3_joint 0.0" doc="Initial joint configuration of the robot"/>
 
   <!-- Load controller settings -->
   <rosparam file="$(arg controller_config_file)" command="load"/>

--- a/ur_gazebo/launch/inc/ur_control.launch.xml
+++ b/ur_gazebo/launch/inc/ur_control.launch.xml
@@ -29,6 +29,9 @@
   <arg name="spawn_z" default="0.1" doc="At which height the model should be spawned. NOTE: lower values will cause the robot to collide with the ground plane." />
   <arg name="start_gazebo" default="true" doc="If true, Gazebo will be started. If false, Gazebo will be assumed to have been started elsewhere." />
 
+  <!--Setting initial configuration -->
+  <arg name="initial_joint_positions" default=" -J shoulder_pan_joint 0.0  -J shoulder_lift_joint -1.54 -J elbow_joint 1.54 -J wrist_1_joint -1.54 -J wrist_2_joint -1.54 -J wrist_3_joint 0.0" doc="Initial joint configuration of the robot"/>
+
   <!-- Load controller settings -->
   <rosparam file="$(arg controller_config_file)" command="load"/>
 
@@ -45,7 +48,9 @@
       -urdf
       -param $(arg robot_description_param_name)
       -model $(arg gazebo_model_name)
-      -z $(arg spawn_z)"
+      -z $(arg spawn_z)
+      $(arg initial_joint_positions)
+      "
     output="screen" respawn="false" />
 
   <!-- Load and start the controllers listed in the 'controllers' arg. -->


### PR DESCRIPTION
The title is self-explanatory.
I introduced an arg "initial_joint_positions" under the ur_control.launch.xml file so to allow the user to set a more comfortable initial joint configuration when launching the robot in Gazebo.

In case this feature is already provided somehow, I did not understand how to use it.

Cheers,

Niccolo