### PR TITLE
Add moveit configs for ur7e and ur12e to metapackage

### DIFF
--- a/universal_robots/package.xml
+++ b/universal_robots/package.xml
@@ -22,6 +22,7 @@
 
   <exec_depend>ur10e_moveit_config</exec_depend>
   <exec_depend>ur10_moveit_config</exec_depend>
+  <exec_depend>ur12e_moveit_config</exec_depend>
   <exec_depend>ur16e_moveit_config</exec_depend>
   <exec_depend>ur20_moveit_config</exec_depend>
   <exec_depend>ur30_moveit_config</exec_depend>
@@ -29,6 +30,7 @@
   <exec_depend>ur3_moveit_config</exec_depend>
   <exec_depend>ur5e_moveit_config</exec_depend>
   <exec_depend>ur5_moveit_config</exec_depend>
+  <exec_depend>ur7e_moveit_config</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>ur_gazebo</exec_depend>
 


### PR DESCRIPTION
While preparing a new release, I realized, that we forgot to add the new moveit configs to the metapackage in #692.

This PR fixes that.