### PR TITLE
Update the inertia matrices for the UR5e and UR3e

### DIFF
--- a/ur_description/config/ur3e/physical_parameters.yaml
+++ b/ur_description/config/ur3e/physical_parameters.yaml
@@ -51,26 +51,25 @@ inertia_parameters:
       y: 0.0        # model.y
       z: -0.02      # model.z
 
-  # compatible with cylinder approximation
   rotation:
     shoulder:
-      roll: 0
+      roll: 1.570796326794897
       pitch: 0
       yaw: 0
     upper_arm:
       roll: 0
-      pitch: 1.570796326794897
+      pitch: 0
       yaw: 0
     forearm:
       roll: 0
-      pitch: 1.570796326794897
+      pitch: 0
       yaw: 0
     wrist_1:
-      roll: 0
+      roll: 1.570796326794897
       pitch: 0
       yaw: 0
     wrist_2:
-      roll: 0
+      roll: -1.570796326794897
       pitch: 0
       yaw: 0
     wrist_3:
@@ -78,47 +77,46 @@ inertia_parameters:
       pitch: 0
       yaw: 0
 
-  # generated using cylinder approximation
   tensor:
     shoulder:
-      ixx: 0.008093166666666665
-      ixy: 0
-      ixz: 0
-      iyy: 0.008093166666666665
-      iyz: 0
-      izz: 0.005625
+      ixx: 0.0027657
+      ixy: 0.0000096
+      ixz: -0.0000149
+      iyy: 0.0021501
+      iyz: 0.0001873
+      izz: 0.0025626
     upper_arm:
-      ixx: 0.021728491912499998
-      ixy: 0
-      ixz: 0
-      iyy: 0.021728491912499998
-      iyz: 0
-      izz: 0.00961875
+      ixx: 0.0042623
+      ixy: -0.0000409
+      ixz: -0.0014960
+      iyy: 0.0460284
+      iyz: -0.0000129
+      izz: 0.0448947
     forearm:
-      ixx: 0.006544570199999999
-      ixy: 0
-      ixz: 0
-      iyy: 0.006544570199999999
-      iyz: 0
-      izz: 0.00354375
+      ixx: 0.0010511
+      ixy: 0.0
+      ixz: -0.0000331
+      iyy: 0.0113396
+      iyz: 0.0000022
+      izz: 0.0110895
     wrist_1:
-      ixx: 0.0020849999999999996
-      ixy: 0
-      ixz: 0
-      iyy: 0.0020849999999999996
-      iyz: 0
-      izz: 0.00225
+      ixx: 0.0008174
+      ixy: -0.0000005
+      ixz: 0.0000021
+      iyy: 0.0006844
+      iyz: 0.0000617
+      izz: 0.0005497
     wrist_2:
-      ixx: 0.0020849999999999996
-      ixy: 0
-      ixz: 0
-      iyy: 0.0020849999999999996
-      iyz: 0
-      izz: 0.00225
+      ixx: 0.0006059
+      ixy: -0.0000006
+      ixz: -0.0000006
+      iyy: 0.0005837
+      iyz: -0.0000271
+      izz: 0.0003831
     wrist_3:
-      ixx: 0.00013626666666666665
-      ixy: 0
-      ixz: 0
-      iyy: 0.00013626666666666665
-      iyz: 0
-      izz: 0.0001792
+      ixx: 0.0001080
+      ixy: -0.0000001
+      ixz: -0.0000001
+      iyy: 0.0001086
+      iyz: -0.0000002
+      izz: 0.0001371

--- a/ur_description/config/ur5e/physical_parameters.yaml
+++ b/ur_description/config/ur5e/physical_parameters.yaml
@@ -51,26 +51,25 @@ inertia_parameters:
       y: 0.0        # model.y
       z: -0.001159  # model.z
 
-  # compatible with cylinder approximation
   rotation:
     shoulder:
-      roll: 0
+      roll: 1.570796326794897
       pitch: 0
       yaw: 0
     upper_arm:
       roll: 0
-      pitch: 1.570796326794897
+      pitch: 0
       yaw: 0
     forearm:
       roll: 0
-      pitch: 1.570796326794897
+      pitch: 0
       yaw: 0
     wrist_1:
-      roll: 0
+      roll: 1.570796326794897
       pitch: 0
       yaw: 0
     wrist_2:
-      roll: 0
+      roll: -1.570796326794897
       pitch: 0
       yaw: 0
     wrist_3:
@@ -78,47 +77,46 @@ inertia_parameters:
       pitch: 0
       yaw: 0
 
-  # generated using cylinder approximation
   tensor:
     shoulder:
-      ixx: 0.010267499999999999
-      ixy: 0
-      ixz: 0
-      iyy: 0.010267499999999999
-      iyz: 0
-      izz: 0.00666
+      ixx: 0.00700210
+      ixy: 0.00000073
+      ixz: -0.00001053
+      iyy: 0.00648091
+      iyz: 0.00049994
+      izz: 0.00657286
     upper_arm:
-      ixx: 0.13388583541666665
-      ixy: 0
-      ixz: 0
-      iyy: 0.13388583541666665
-      iyz: 0
-      izz: 0.0151074
+      ixx: 0.01505885
+      ixy: -0.00005400
+      ixz: 0.00000563
+      iyy: 0.33388086
+      iyz: -0.00000181
+      izz: 0.33247207
     forearm:
-      ixx: 0.03120936758333333
-      ixy: 0
-      ixz: 0
-      iyy: 0.03120936758333333
-      iyz: 0
-      izz: 0.004095
+      ixx: 0.00399632
+      ixy: -0.00001365
+      ixz: 0.00137272
+      iyy: 0.07879254
+      iyz: -0.00000660
+      izz: 0.07848510
     wrist_1:
-      ixx: 0.0025599
-      ixy: 0
-      ixz: 0
-      iyy: 0.0025599
-      iyz: 0
-      izz: 0.0021942
+      ixx: 0.00165491
+      ixy: -0.00000282
+      ixz: -0.00000438
+      iyy: 0.00135962
+      iyz: 0.00010157
+      izz: 0.00126279
     wrist_2:
-      ixx: 0.0025599
-      ixy: 0
-      ixz: 0
-      iyy: 0.0025599
-      iyz: 0
-      izz: 0.0021942
+      ixx: 0.00135617
+      ixy: -0.00000274
+      ixz: 0.00000444
+      iyy: 0.00127827
+      iyz: -0.00005048
+      izz: 0.00096614
     wrist_3:
-      ixx: 9.890414008333333e-05
-      ixy: 0
-      ixz: 0
-      iyy: 9.890414008333333e-05
-      iyz: 0
-      izz: 0.0001321171875
+      ixx: 0.00018694
+      ixy: 0.00000006
+      ixz: -0.00000017
+      iyy: 0.00018908
+      iyz: -0.00000092
+      izz: 0.00025756


### PR DESCRIPTION
They have been updated from the CAD model and should be more accurate than the cylinder approximations.

This is basically a ROS 1 backport of https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/256 and https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/278