### PR TITLE
ci: pin runner image to Noble

### DIFF
--- a/.github/workflows/ci_noetic.yml
+++ b/.github/workflows/ci_noetic.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   industrial_ci:
     name: ROS Noetic (${{ matrix.ros_repo }})
-    runs-on: ubuntu-latest # the ICI job itself will be running in a container.
+    runs-on: ubuntu-24.04 # the ICI job itself will be running in a container.
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
As per title.

Keeps us in control of which runner image is used to run actions on.

We don't typically like *moving targets* that can be changed without notification.
