### PR TITLE
Update setup.py

### DIFF
--- a/ur_kinematics/setup.py
+++ b/ur_kinematics/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Dear UR team,
Recently, I reinstalled my Ubuntu 20.04 system and ROS Noetic, also the UR driver for our UR5e robot on Ubuntu 20.04 based on ROS Noetic, however, the last step to cmake the whole library has something wrong ,as shown below: 

![image](https://github.com/user-attachments/assets/4c792053-c0ca-475c-963e-24900daef242)

Finally, I found the problem happened for the setup.py file and the library needs to be changed from "**distutils.core**" to "**setuptools**" . Then the problem has been dealt with.

I think the problem is caused by the Python library update, so it would be better to use this library to avoid any similar error from happening for all the other users.


