### PR TITLE
[ROS-O] drop obsolete boost component system

### DIFF
--- a/ur_kinematics/CMakeLists.txt
+++ b/ur_kinematics/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ur_kinematics)
 find_package(catkin REQUIRED COMPONENTS roscpp geometry_msgs moveit_core moveit_kinematics
   moveit_ros_planning pluginlib tf_conversions)
 
-find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED)
 
 catkin_python_setup()
 


### PR DESCRIPTION
which has been empty for a long time and finally got removed from boost's cmake interface.
This fails with Ubuntu 26.04 and newer.